### PR TITLE
Change code viewer from RichText to Scintilla

### DIFF
--- a/src/utils/stringutils.cpp
+++ b/src/utils/stringutils.cpp
@@ -307,14 +307,13 @@ void readQuote(std::wistream& stream, std::wstring& str_out)
 	}
 }
 
-
-StringSet::StringSet(const wchar_t *file, bool caseCheck)
+template<typename T>
+static void Parse(const wchar_t *file, T* dst)
 {
 	FILE *fp;
 	wchar_t path[MAX_PATH];
 	wcscpy(path, file);
 
-	this->caseCheck = caseCheck;
 	fp = _wfopen(path, L"r");
 
 	if (!fp) {
@@ -346,9 +345,15 @@ StringSet::StringSet(const wchar_t *file, bool caseCheck)
 		while(end != start && isspace(*end))
 			*end-- = 0;
 
-		Add(start);
+		dst->Add(start);
 	}
 	fclose(fp);
+}
+
+StringSet::StringSet(const wchar_t *file, bool caseCheck)
+{
+	this->caseCheck = caseCheck;
+	Parse(file, this);
 }
 
 void StringSet::Add(const wchar_t *string)
@@ -404,4 +409,15 @@ bool StringSet::Contains(const wchar_t *str) const
 	}
 
 	return false;
+}
+
+StringList::StringList(const wchar_t *file)
+{
+	Parse(file, this);
+}
+
+void StringList::Add(const wchar_t *str)
+{
+	string.append(str);
+	string.append(L" ");
 }

--- a/src/utils/stringutils.h
+++ b/src/utils/stringutils.h
@@ -134,5 +134,13 @@ public:
 };
 
 
+struct StringList
+{
+	std::wstring string;
+public:
+	StringList(const wchar_t *file);
+	void Add(const wchar_t *str);
+	const std::wstring& Get() const { return string; }
+};
 
 #endif //__STRINGUTILS_H__

--- a/src/wxProfilerGUI/sourceview.h
+++ b/src/wxProfilerGUI/sourceview.h
@@ -26,6 +26,8 @@ http://www.gnu.org/copyleft/gpl.html.
 
 #include "profilergui.h"
 
+#include <wx/stc/stc.h>
+
 class MainWin;
 
 /*=====================================================================
@@ -33,7 +35,7 @@ SourceView
 ----------
 
 =====================================================================*/
-class SourceView : public wxTextCtrl
+class SourceView : public wxStyledTextCtrl
 {
 public:
 	/*=====================================================================
@@ -52,6 +54,10 @@ public:
 
 	const std::wstring& getCurrentFile() const { return currentfile; }
 private:
+	void setPlainMode();
+	void setCppMode();
+	void updateText(const wxString& text);
+
 	std::wstring currentfile;
 	MainWin* mainwin;
 
@@ -61,7 +67,7 @@ private:
 
 enum
 {
-    SOURCE_VIEW                   = 1005
+	SOURCE_VIEW					  = 1005
 };
 
 


### PR DESCRIPTION
Using Scintilla wxWidgets widget, I changed the code viewer from parsing code and setting up a RichText widget, to letting Scintilla parse it and format it. The advantages are:

1) "Better" parser, easily tweakable
2) Line numbers (in the margin)
3) Per line timings in the margin
4) Less code :)

What could be improved:
1) Line numbers are always active. Could be an option