### PR TITLE
Early profiling using debugging API and other improvements

### DIFF
--- a/sleepy-v12.sln
+++ b/sleepy-v12.sln
@@ -1,5 +1,7 @@
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.31101.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "sleepy", "sleepy.vcxproj", "{E3D8AA66-3F5A-46C9-AAB2-34D3CE44E5DC}"
 	ProjectSection(ProjectDependencies) = postProject
 		{583D5F0A-7047-48BA-BE65-80B775513463} = {583D5F0A-7047-48BA-BE65-80B775513463}

--- a/sleepy.sln.cmd
+++ b/sleepy.sln.cmd
@@ -1,0 +1,13 @@
+set WXWIN=C:\Prj\3rdParty\wxWidgets\2.9.5\
+
+if exist "%VS120COMNTOOLS%vsvars32.bat" (
+call "%VS120COMNTOOLS%vsvars32.bat"
+) else if exist "%VS110COMNTOOLS%vsvars32.bat" (
+call "%VS110COMNTOOLS%vsvars32.bat"
+) else if exist "%VS100COMNTOOLS%vsvars32.bat" (
+call "%VS100COMNTOOLS%vsvars32.bat"
+)
+
+del %~dp0*.sdf
+@rem rmdir /s /q %~dp0x64
+start devenv.com %~dp0sleepy-v12.sln

--- a/sleepy.vcxproj
+++ b/sleepy.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -28,18 +28,22 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -102,12 +106,11 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>comctl32.lib;rpcrt4.lib;shlwapi.lib;psapi.lib;crashback.lib;dbgeng.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comctl32.lib;advapi32.lib;shlwapi.lib;psapi.lib;crashback.lib;dbgeng.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)sleepy.exe</OutputFile>
       <AdditionalLibraryDirectories>$(WXWIN)\lib\vc_lib;src/crashback/bin/$(Platform)/$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <DelayLoadDLLs>%(DelayLoadDLLs)</DelayLoadDLLs>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <ProgramDatabaseFile>$(OutDir)sleepy.pdb</ProgramDatabaseFile>
+      <ProgramDatabaseFile>$(TargetDir)$(TargetName).pdb</ProgramDatabaseFile>
       <SubSystem>Windows</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention>
@@ -188,7 +191,7 @@
     </Midl>
     <ClCompile>
       <AdditionalIncludeDirectories>$(WXWIN)\include;$(WXWIN)\include\msvc;src/crashback/src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_WIN64;WIN32;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PrecompiledHeader>
       </PrecompiledHeader>

--- a/src/crashback/badapp/badapp.vcxproj
+++ b/src/crashback/badapp/badapp.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -28,19 +28,23 @@
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/src/crashback/src/crashback.vcxproj
+++ b/src/crashback/src/crashback.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -29,19 +29,23 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>false</WholeProgramOptimization>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>false</WholeProgramOptimization>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/src/crashback/src/crashreport.vcxproj
+++ b/src/crashback/src/crashreport.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -28,19 +28,23 @@
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>NotSet</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>NotSet</CharacterSet>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>NotSet</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>NotSet</CharacterSet>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/src/profiler/processinfo.cpp
+++ b/src/profiler/processinfo.cpp
@@ -34,12 +34,11 @@ ProcessInfo::ProcessInfo(DWORD id_, const std::wstring& name_, HANDLE process_ha
 {
 	prevKernelTime.dwHighDateTime = prevKernelTime.dwLowDateTime = 0;
 	prevUserTime.dwHighDateTime = prevUserTime.dwLowDateTime = 0;
-  cpuUsage = -1;
+    cpuUsage = -1;
 #ifdef _WIN64
 	is64Bits = Is64BitProcess(process_handle);
 #endif
 }
-
 
 ProcessInfo::~ProcessInfo()
 {
@@ -49,48 +48,40 @@ void ProcessInfo::enumProcesses(std::vector<ProcessInfo>& processes_out)
 {
 	HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS | TH32CS_SNAPTHREAD, 0);
 
-
-	PROCESSENTRY32 processinfo;
+    PROCESSENTRY32 processinfo = {0};
 	processinfo.dwSize = sizeof(PROCESSENTRY32);
 
 	if (Process32First(snapshot, &processinfo))
 	{
 		do
 		{
-			std::wstring processname = processinfo.szExeFile;
-
-
 			const DWORD process_id = processinfo.th32ProcessID;
 
 			// Don't allow profiling our own process. Bad things happen.
-			if ( process_id == GetCurrentProcessId() )
-				continue;
+            if (process_id == GetCurrentProcessId())
+            {
+                continue;
+            }
 
 			//------------------------------------------------------------------------
 			//Get the actual handle of the process
 			//------------------------------------------------------------------------
-			HANDLE process_handle = OpenProcess (PROCESS_ALL_ACCESS, FALSE, process_id);
+            const HANDLE process_handle = OpenProcess(PROCESS_ALL_ACCESS, FALSE, process_id);
 
 			// Skip processes we don't have permission to.
-			if(process_handle == NULL) {
+			if (process_handle == NULL)
+            {
 				continue;
 			}
 
-#ifndef _WIN64
-			// If the process is 64 bit, skip it.
-			if(Is64BitProcess(process_handle)) {
-				CloseHandle(process_handle);
-				continue;
-			}
-#else
-			// Skip 32 bit processes on system that does not have the needed functions (Windows XP 64).
-			if((fn_Wow64SuspendThread == NULL || fn_Wow64GetThreadContext == NULL) && !Is64BitProcess(process_handle)) {
-				CloseHandle(process_handle);
-				continue;
-			}
-#endif
+            if (!CanProfileProcess(process_handle))
+            {
+                CloseHandle(process_handle);
+                continue;
+            }
 
-			processes_out.push_back(ProcessInfo(process_id, processname, process_handle));
+            const std::wstring processname = processinfo.szExeFile;
+            processes_out.push_back(ProcessInfo(process_id, processname, process_handle));
 
 			processinfo.dwSize = sizeof(PROCESSENTRY32);
 		}
@@ -128,9 +119,3 @@ void ProcessInfo::enumProcesses(std::vector<ProcessInfo>& processes_out)
 
 	CloseHandle(snapshot);
 }
-
-
-
-
-
-

--- a/src/profiler/processinfo.cpp
+++ b/src/profiler/processinfo.cpp
@@ -4,6 +4,7 @@ processinfo.cpp
 File created by ClassTemplate on Sun Mar 20 03:22:27 2005
 
 Copyright (C) Nicholas Chapman
+Copyright (C) 2015 Ashod Nakashian
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -34,7 +35,7 @@ ProcessInfo::ProcessInfo(DWORD id_, const std::wstring& name_, HANDLE process_ha
 {
 	prevKernelTime.dwHighDateTime = prevKernelTime.dwLowDateTime = 0;
 	prevUserTime.dwHighDateTime = prevUserTime.dwLowDateTime = 0;
-    cpuUsage = -1;
+	cpuUsage = -1;
 #ifdef _WIN64
 	is64Bits = Is64BitProcess(process_handle);
 #endif
@@ -48,7 +49,7 @@ void ProcessInfo::enumProcesses(std::vector<ProcessInfo>& processes_out)
 {
 	HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS | TH32CS_SNAPTHREAD, 0);
 
-    PROCESSENTRY32 processinfo = {0};
+	PROCESSENTRY32 processinfo = {0};
 	processinfo.dwSize = sizeof(PROCESSENTRY32);
 
 	if (Process32First(snapshot, &processinfo))
@@ -58,30 +59,30 @@ void ProcessInfo::enumProcesses(std::vector<ProcessInfo>& processes_out)
 			const DWORD process_id = processinfo.th32ProcessID;
 
 			// Don't allow profiling our own process. Bad things happen.
-            if (process_id == GetCurrentProcessId())
-            {
-                continue;
-            }
+			if (process_id == GetCurrentProcessId())
+			{
+				continue;
+			}
 
 			//------------------------------------------------------------------------
 			//Get the actual handle of the process
 			//------------------------------------------------------------------------
-            const HANDLE process_handle = OpenProcess(PROCESS_ALL_ACCESS, FALSE, process_id);
+			const HANDLE process_handle = OpenProcess(PROCESS_ALL_ACCESS, FALSE, process_id);
 
 			// Skip processes we don't have permission to.
 			if (process_handle == NULL)
-            {
+			{
 				continue;
 			}
 
-            if (!CanProfileProcess(process_handle))
-            {
-                CloseHandle(process_handle);
-                continue;
-            }
+			if (!CanProfileProcess(process_handle))
+			{
+				CloseHandle(process_handle);
+				continue;
+			}
 
-            const std::wstring processname = processinfo.szExeFile;
-            processes_out.push_back(ProcessInfo(process_id, processname, process_handle));
+			const std::wstring processname = processinfo.szExeFile;
+			processes_out.push_back(ProcessInfo(process_id, processname, process_handle));
 
 			processinfo.dwSize = sizeof(PROCESSENTRY32);
 		}

--- a/src/profiler/profiler.cpp
+++ b/src/profiler/profiler.cpp
@@ -32,6 +32,7 @@ http://www.gnu.org/copyleft/gpl.html..
 #include <assert.h>
 #include <winnt.h>
 #include "../utils/dbginterface.h"
+#include "../utils/WoW64.h"
 
 #ifdef _WIN64
 #define CONTEXT64_FLAGS		(CONTEXT_AMD64 | CONTEXT_FULL)
@@ -52,7 +53,7 @@ Profiler::Profiler(HANDLE target_process_, HANDLE target_thread_,
 	target_thread(target_thread_),
 	callstacks(callstacks_),
 	flatcounts(flatcounts_),
-    is64BitProcess(Is64BitProcess(target_process))
+    is64BitProcess(Is64BitProcess(target_process_))
 {
 }
 

--- a/src/profiler/profiler.cpp
+++ b/src/profiler/profiler.cpp
@@ -51,9 +51,9 @@ Profiler::Profiler(HANDLE target_process_, HANDLE target_thread_,
 :	target_process(target_process_),
 	target_thread(target_thread_),
 	callstacks(callstacks_),
-	flatcounts(flatcounts_)
+	flatcounts(flatcounts_),
+    is64BitProcess(Is64BitProcess(target_process))
 {
-	is64BitProcess = Is64BitProcess(target_process);
 }
 
 // DE: 20090325: Need copy constructor since it is put in a std::vector

--- a/src/profiler/profiler.cpp
+++ b/src/profiler/profiler.cpp
@@ -4,6 +4,7 @@ profiler.cpp
 File created by ClassTemplate on Thu Feb 24 19:00:30 2005
 
 Copyright (C) Nicholas Chapman
+Copyright (C) 2015 Ashod Nakashian
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -53,7 +54,7 @@ Profiler::Profiler(HANDLE target_process_, HANDLE target_thread_,
 	target_thread(target_thread_),
 	callstacks(callstacks_),
 	flatcounts(flatcounts_),
-    is64BitProcess(Is64BitProcess(target_process_))
+	is64BitProcess(Is64BitProcess(target_process_))
 {
 }
 

--- a/src/profiler/profiler.h
+++ b/src/profiler/profiler.h
@@ -108,7 +108,7 @@ public:
 	// DE: 20090325: Profiler no longer owns callstack and flatcounts since it is shared between multipler profilers
 	std::map<CallStack, SAMPLE_TYPE>& callstacks;
 	std::map<PROFILER_ADDR, SAMPLE_TYPE>& flatcounts;
-	bool is64BitProcess;
+	const bool is64BitProcess;
 
 	bool sampleTarget(SAMPLE_TYPE timeSpent, SymbolInfo *syminfo);//throws ProfilerExcep
 	bool targetExited() const;

--- a/src/profiler/profilerthread.cpp
+++ b/src/profiler/profilerthread.cpp
@@ -66,7 +66,7 @@ ProfilerThread::~ProfilerThread()
 }
 
 
-void ProfilerThread::sample(SAMPLE_TYPE timeSpent)
+void ProfilerThread::sample(const SAMPLE_TYPE timeSpent)
 {
 	// DE: 20090325: Profiler has a list of threads to profile, one Profiler instance per thread
 	// RJM- We traverse them in random order. The act of profiling causes the Windows scheduler
@@ -74,7 +74,7 @@ void ProfilerThread::sample(SAMPLE_TYPE timeSpent)
 	//      This starves the other N-1 threads. For lack of a better option, using a shuffle
 	//      at least re-schedules them evenly.
 
-	size_t count = profilers.size();
+	const size_t count = profilers.size();
 	if ( count == 0)
 		return;
 
@@ -89,16 +89,17 @@ void ProfilerThread::sample(SAMPLE_TYPE timeSpent)
 	}
 
 	int numSuccessful = 0;
-	for (size_t n=0;n<count;n++)
+	for (size_t n = 0;n < count; ++n)
 	{
 		Profiler& profiler = profilers[order[n]];
 		try {
 			if (profiler.sampleTarget(timeSpent, sym_info))
 			{
-				numsamplessofar++;
-				numSuccessful++;
+				++numsamplessofar;
+				++numSuccessful;
 			}
-		} catch( ProfilerExcep &e )
+		}
+        catch (const ProfilerExcep& e)
 		{
 			error(_T("ProfilerExcep: ") + e.what());
 			this->commit_suicide = true;

--- a/src/profiler/profilerthread.cpp
+++ b/src/profiler/profilerthread.cpp
@@ -99,7 +99,7 @@ void ProfilerThread::sample(const SAMPLE_TYPE timeSpent)
 				++numSuccessful;
 			}
 		}
-        catch (const ProfilerExcep& e)
+		catch (const ProfilerExcep& e)
 		{
 			error(_T("ProfilerExcep: ") + e.what());
 			this->commit_suicide = true;
@@ -122,6 +122,9 @@ void ProfilerThread::sampleLoop()
 {
 	timeBeginPeriod(1);
 
+	const int ms = 100 / prefs.throttle;
+	const double secs = ms / 1000.0;
+
 	LARGE_INTEGER prev, now, start, freq;
 	QueryPerformanceFrequency(&freq);
 	QueryPerformanceCounter(&start);
@@ -137,27 +140,36 @@ void ProfilerThread::sampleLoop()
 			continue;
 		}
 
-		QueryPerformanceCounter(&now);
-
-		__int64 diff = now.QuadPart - prev.QuadPart;
-		double t = (double)diff / (double)freq.QuadPart;
-
-		__int64 elapsed = now.QuadPart - start.QuadPart;
-		if (!minidump_saved && prefs.saveMinidump>=0 && elapsed >= prefs.saveMinidump * freq.QuadPart)
+		if (ms > 5)
 		{
-			minidump_saved = true;
-			status = L"Saving minidump";
-			minidump = sym_info->saveMinidump();
-			status = NULL;
-			continue;
+			Sleep(ms);
+		}
+
+		double t = ms;
+		do
+		{
+			QueryPerformanceCounter(&now);
+			const __int64 diff = now.QuadPart - prev.QuadPart;
+			t = (double)diff / (double)freq.QuadPart;
+		}
+		while (secs > t);
+
+		if (!minidump_saved && prefs.saveMinidump >= 0)
+		{
+			const __int64 elapsed = now.QuadPart - start.QuadPart;
+			if (elapsed >= prefs.saveMinidump * freq.QuadPart)
+			{
+				minidump_saved = true;
+				status = L"Saving minidump";
+				minidump = sym_info->saveMinidump();
+				status = NULL;
+				continue;
+			}
 		}
 
 		sample(t);
+		QueryPerformanceCounter(&prev);
 
-		int ms = 100 / prefs.throttle;
-		Sleep(ms);
-
-		prev = now;
 	}
 
 	timeEndPeriod(1);

--- a/src/profiler/profilerthread.h
+++ b/src/profiler/profilerthread.h
@@ -74,7 +74,7 @@ public:
 	void setPaused(bool paused_) { paused = paused_; }
 	void cancel() { cancelled = true; }
 
-	void sample(SAMPLE_TYPE timeSpent);//for internal use.
+	void sample(const SAMPLE_TYPE timeSpent);//for internal use.
 private:
 	//std::wstring demangleProcName(const std::wstring& mangled_name);
 	void error(const std::wstring& what);

--- a/src/utils/except.h
+++ b/src/utils/except.h
@@ -28,7 +28,7 @@ public:
 	SleepyException(const wchar_t *what)
 		: std::runtime_error(helper(what)), _what(what) {}
 
-	const std::wstring &wwhat() { return _what; }
+	const std::wstring &wwhat() const { return _what; }
 };
 
 template<typename T, typename S>

--- a/src/utils/osutils.cpp
+++ b/src/utils/osutils.cpp
@@ -34,13 +34,13 @@ static IsWow64Process_t *IsWow64ProcessPtr = NULL;
 
 void InitSysInfo()
 {
-    SYSTEM_INFO systemInfo = { 0 };
-    GetNativeSystemInfo(&systemInfo);
-    totalCpuCount = systemInfo.dwNumberOfProcessors;
-    is64BitOS = (systemInfo.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_AMD64);
+	SYSTEM_INFO systemInfo = { 0 };
+	GetNativeSystemInfo(&systemInfo);
+	totalCpuCount = systemInfo.dwNumberOfProcessors;
+	is64BitOS = (systemInfo.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_AMD64);
 
-    is64BitProfiler = (sizeof(void*) > 4);
-    IsWow64ProcessPtr = (IsWow64Process_t *)GetProcAddress(GetModuleHandle(L"kernel32"), "IsWow64Process");
+	is64BitProfiler = (sizeof(void*) > 4);
+	IsWow64ProcessPtr = (IsWow64Process_t *)GetProcAddress(GetModuleHandle(L"kernel32"), "IsWow64Process");
 }
 
 int GetCPUCores()
@@ -105,35 +105,35 @@ Profiler | Profilee | OS
 
 bool CanProfileProcess(HANDLE hProcess)
 {
-    if (Is64BitProcess(hProcess))
-    {
-        // 64-bit with a 64-bit profiler only.
-        return is64BitProfiler;
-    }
+	if (Is64BitProcess(hProcess))
+	{
+		// 64-bit with a 64-bit profiler only.
+		return is64BitProfiler;
+	}
 
-    //TODO: Check security permissions?
+	//TODO: Check security permissions?
 
 #ifdef _WIN64
-    if (fn_Wow64SuspendThread == NULL || fn_Wow64GetThreadContext == NULL)
-    {
-        // Skip 32 bit processes on system that does not have the needed functions (Windows XP 64).
-        return false;
-    }
+	if (fn_Wow64SuspendThread == NULL || fn_Wow64GetThreadContext == NULL)
+	{
+		// Skip 32 bit processes on system that does not have the needed functions (Windows XP 64).
+		return false;
+	}
 #endif
 
-    // Any 32-bit profilee is supported.
-    return true;
+	// Any 32-bit profilee is supported.
+	return true;
 }
 
 bool Is64BitProcess(HANDLE hProcess)
 {
-    // If the process is running under 32-bit Windows, the value is set to FALSE.
-    // If the process is a 64-bit application running under 64-bit Windows, the value is also set to FALSE.
-    // Meaning, this is TRUE if, and only if, the process is 32-bits running under 64-bit Windows.
-    BOOL isWow64Process;
+	// If the process is running under 32-bit Windows, the value is set to FALSE.
+	// If the process is a 64-bit application running under 64-bit Windows, the value is also set to FALSE.
+	// Meaning, this is TRUE if, and only if, the process is 32-bits running under 64-bit Windows.
+	BOOL isWow64Process;
 
-    return (is64BitOS &&
-            IsWow64ProcessPtr &&
-            IsWow64ProcessPtr(hProcess, &isWow64Process) &&
-            !isWow64Process);
+	return (is64BitOS &&
+			IsWow64ProcessPtr &&
+			IsWow64ProcessPtr(hProcess, &isWow64Process) &&
+			!isWow64Process);
 }

--- a/src/utils/osutils.cpp
+++ b/src/utils/osutils.cpp
@@ -1,8 +1,9 @@
 /*=====================================================================
-sortlist.cpp
+osutils.cpp
 ------------
 
 Copyright (C) Dan Engelbrecht
+Copyright (C) 2015 Ashod Nakashian
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -20,13 +21,31 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 http://www.gnu.org/copyleft/gpl.html.
 =====================================================================*/
-#include "osutils.h"
 
-int GetCPUCores(){
-	SYSTEM_INFO systemInfo;
-	::GetSystemInfo(&systemInfo);
-	__int64 cpuCount = systemInfo.dwNumberOfProcessors;
-	return static_cast<int>(cpuCount);
+#include "osutils.h"
+#include "WoW64.h"
+
+static bool is64BitOS = false;
+static bool is64BitProfiler = false;
+static int totalCpuCount = 1;
+
+typedef BOOL WINAPI IsWow64Process_t(__in HANDLE hProcess, __out PBOOL Wow64Process);
+static IsWow64Process_t *IsWow64ProcessPtr = NULL;
+
+void InitSysInfo()
+{
+    SYSTEM_INFO systemInfo = { 0 };
+    GetNativeSystemInfo(&systemInfo);
+    totalCpuCount = systemInfo.dwNumberOfProcessors;
+    is64BitOS = (systemInfo.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_AMD64);
+
+    is64BitProfiler = (sizeof(void*) > 4);
+    IsWow64ProcessPtr = (IsWow64Process_t *)GetProcAddress(GetModuleHandle(L"kernel32"), "IsWow64Process");
+}
+
+int GetCPUCores()
+{
+	return totalCpuCount;
 }
 
 int GetCountFromBitMask(DWORD bitMask){
@@ -52,7 +71,6 @@ int GetCoresForProcess(HANDLE process){
 	}
 }
 
-
 void EnableDebugPrivilege()
 {
 	HANDLE hToken;
@@ -72,38 +90,50 @@ void EnableDebugPrivilege()
 	CloseHandle( hToken );
 }
 
-bool Is64BitProcess(HANDLE hProcess)
+/*
+Bitness possibility matrix.
+
+Profiler | Profilee | OS
+-----------------------------
+32-bits  | 32-bits  | 32-bits   (Native)
+32-bits  | 32-bits  | WOW64
+32-bits  | 64-bits  | 64-bits   (Unsupported)
+
+64-bits  | 32-bits  | WOW64
+64-bits  | 64-bits  | 64-bits   (Native)
+*/
+
+bool CanProfileProcess(HANDLE hProcess)
 {
-	typedef BOOL WINAPI IsWow64Process_t(__in   HANDLE hProcess,__out  PBOOL Wow64Process);
-	static bool first = true;
-	static IsWow64Process_t *IsWow64ProcessPtr = NULL;
+    if (Is64BitProcess(hProcess))
+    {
+        // 64-bit with a 64-bit profiler only.
+        return is64BitProfiler;
+    }
 
-#ifndef _WIN64
-	static BOOL isOn64BitOs = 0;
+    //TODO: Check security permissions?
+
+#ifdef _WIN64
+    if (fn_Wow64SuspendThread == NULL || fn_Wow64GetThreadContext == NULL)
+    {
+        // Skip 32 bit processes on system that does not have the needed functions (Windows XP 64).
+        return false;
+    }
 #endif
 
-	if (first) {
-		first = false;
-		IsWow64ProcessPtr = (IsWow64Process_t *)GetProcAddress(GetModuleHandle(L"kernel32"),"IsWow64Process");
-#ifndef _WIN64
-		if (!IsWow64ProcessPtr)
-			return false;
-		IsWow64ProcessPtr(GetCurrentProcess(),&isOn64BitOs);
-#endif
-	}
-
-#ifndef _WIN64
-	if(!isOn64BitOs) {
-		return false;
-	}
-#endif
-
-	if(IsWow64ProcessPtr) {
-		BOOL isWow64Process;
-		if(IsWow64ProcessPtr(hProcess,&isWow64Process) && !isWow64Process) {
-			return true;
-		}
-	}
-	return false;
+    // Any 32-bit profilee is supported.
+    return true;
 }
 
+bool Is64BitProcess(HANDLE hProcess)
+{
+    // If the process is running under 32-bit Windows, the value is set to FALSE.
+    // If the process is a 64-bit application running under 64-bit Windows, the value is also set to FALSE.
+    // Meaning, this is TRUE if, and only if, the process is 32-bits running under 64-bit Windows.
+    BOOL isWow64Process;
+
+    return (is64BitOS &&
+            IsWow64ProcessPtr &&
+            IsWow64ProcessPtr(hProcess, &isWow64Process) &&
+            !isWow64Process);
+}

--- a/src/utils/osutils.h
+++ b/src/utils/osutils.h
@@ -3,6 +3,7 @@ osutils.h
 ----------
 
 Copyright (C) Dan Engelbrecht
+Copyright (C) 2015 Ashod Nakashian
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -20,15 +21,18 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 http://www.gnu.org/copyleft/gpl.html.
 =====================================================================*/
-#ifndef __OSUTILS_H_666_
-#define __OSUTILS_H_666_
+
+#ifndef __OSUTILS_H__
+#define __OSUTILS_H__
 
 #include <windows.h>
-#include "wow64.h"
 
+void InitSysInfo();
 int GetCPUCores();
 int GetCoresForProcess(HANDLE process);
 void EnableDebugPrivilege();
 bool Is64BitProcess(HANDLE hProcess);
 
-#endif // __OSUTILS_H_666_
+bool CanProfileProcess(HANDLE hProcess);
+
+#endif // __OSUTILS_H__

--- a/src/wxProfilerGUI/database.cpp
+++ b/src/wxProfilerGUI/database.cpp
@@ -279,14 +279,15 @@ void Database::loadCallstacks(wxInputStream &file,bool collapseKernelCalls)
 
 		if (collapseKernelCalls)
 		{
-			if (callstack.addresses.size() && addrinfo.at(callstack.addresses[0]).symbol->isCollapseModule)
+			if (callstack.addresses.size() >= 2 && addrinfo.at(callstack.addresses[0]).symbol->isCollapseModule)
 			{
-				while (callstack.addresses.size() >= 2)
+				do
 				{
 					if (!addrinfo.at(callstack.addresses[1]).symbol->isCollapseModule)
 						break;
 					callstack.addresses.erase(callstack.addresses.begin());
 				}
+                while (callstack.addresses.size() >= 2);
 			}
 		}
 
@@ -294,7 +295,7 @@ void Database::loadCallstacks(wxInputStream &file,bool collapseKernelCalls)
 		for (size_t i=0; i<callstack.addresses.size(); i++)
 			callstack.symbols[i] = addrinfo.at(callstack.addresses[i]).symbol;
 
-		callstacks.push_back(std::move(callstack));
+		callstacks.emplace_back(std::move(callstack));
 
 		wxFileOffset offset = file.TellI();
 		if (offset != wxInvalidOffset && offset != filesize)
@@ -320,16 +321,17 @@ void Database::loadCallstacks(wxInputStream &file,bool collapseKernelCalls)
 		progressdlg.Update(0, "Filtering...");
 
 		std::vector<CallStack> filtered;
-		for (auto i = callstacks.begin(); i != callstacks.end(); ++i)
+        const auto total = callstacks.size();
+		for (auto i = 0; i < total; ++i)
 		{
-			int n = i - callstacks.begin();
-			if (n % 256 == 0)
-				progressdlg.Update(kMaxProgress * n / callstacks.size());
+			if (i % 256 == 0)
+				progressdlg.Update(kMaxProgress * i / total);
 
-			if (!filtered.empty() && filtered.back().addresses == i->addresses)
-				filtered.back().samplecount += i->samplecount;
+            auto& item = callstacks[i];
+			if (!filtered.empty() && filtered.back().addresses == item.addresses)
+                filtered.back().samplecount += item.samplecount;
 			else
-				filtered.push_back(*i);
+				filtered.emplace_back(std::move(item));
 		}
 
 		std::swap(filtered, callstacks);
@@ -405,38 +407,40 @@ void Database::scanMainList()
 		(int)callstacks.size(), theMainWin,
 		wxPD_APP_MODAL|wxPD_AUTO_HIDE);
 
-	mainList.items.clear();
-	mainList.totalcount = 0;
+    mainList.items.clear();
+    mainList.items.reserve(symbols.size());
+    mainList.totalcount = 0;
 
 	Symbol::ID currentRootID = currentRoot ? currentRoot->id : -1;
 
 	int progress = 0;
-	for (auto i = callstacks.begin(); i != callstacks.end(); ++i)
-	{  
+	for (auto& it = callstacks.begin(); it != callstacks.end(); ++it)
+	{
+        const auto& i = *it;
 		// Only use call stacks that include the current root
-		if (!includeCallstack(*i)) continue;
+		if (!includeCallstack(i)) continue;
 
-		exclusive[i->symbols[0]->id] += i->samplecount;
+		exclusive[i.symbols[0]->id] += i.samplecount;
 		std::vector<bool> seen(symbols.size());
-		for (size_t n=0;n<i->symbols.size();n++)
+		for (size_t n = 0; n < i.symbols.size(); ++n)
 		{
-			Symbol::ID id = i->symbols[n]->id;
+			Symbol::ID id = i.symbols[n]->id;
 
 			// we filter out duplicates, to avoid getting funny numbers when 
 			// using recursive functions.
 			if (!seen[id])
 			{
-				inclusive[id] += i->samplecount;
+				inclusive[id] += i.samplecount;
 				seen[id] = true;
 			} 
 			if (id == currentRootID) break;       // Stop handling the call stack if we encounter the root
 		}
-		mainList.totalcount += i->samplecount;
+		mainList.totalcount += i.samplecount;
 
 		progressdlg.Update(progress++);
 	}
 
-	for (Symbol::ID id=0; id < symbols.size(); id++)
+	for (Symbol::ID id = 0; id < symbols.size(); ++id)
 	{
 		Item item;
 		item.symbol = symbols[id];
@@ -450,17 +454,18 @@ void Database::scanMainList()
 std::vector<const Database::CallStack*> Database::getCallstacksContaining(const Database::Symbol *symbol) const
 {
 	std::vector<const CallStack *> ret;
-	for (auto i = callstacks.begin(); i != callstacks.end(); ++i)
-	{ 
+	for (auto& it = callstacks.begin(); it != callstacks.end(); ++it)
+	{
+        const auto& i = *it;
 		// Only use call stacks that include the current root
-		if (!includeCallstack(*i)) continue;
+		if (!includeCallstack(i)) continue;
 
 		// Only include callstacks that have our symbol in.
-		for (size_t n=0;n<i->symbols.size();n++)
+		for (size_t n=0;n<i.symbols.size();n++)
 		{
-			if (i->symbols[n] == symbol)
+			if (i.symbols[n] == symbol)
 			{
-				ret.push_back(&*i);
+				ret.push_back(&i);
 				break;
 			}
 		}
@@ -472,22 +477,23 @@ Database::List Database::getCallers(const Database::Symbol *symbol) const
 {
 	List list;
 	std::map<Address, double> counts;
-	for (auto i = callstacks.begin(); i != callstacks.end(); ++i)
-	{ 
+	for (auto& it = callstacks.begin(); it != callstacks.end(); ++it)
+	{
+        const auto& i = *it;
 		// Only use call stacks that include the current root
-		if (!includeCallstack(*i)) continue;
+		if (!includeCallstack(i)) continue;
 
 		// Only include callstacks that have our symbol in.
-		for (size_t n=0;n<i->symbols.size()-1;n++)
+		for (size_t n=0;n<i.symbols.size()-1;n++)
 		{
-			const Symbol *s = i->symbols[n];
+			const Symbol *s = i.symbols[n];
 			if (s == currentRoot) break;       // Stop handling the call stack if we encounter the root
 			if (s == symbol)
 			{
-				Address caller = i->addresses[n+1];
+				Address caller = i.addresses[n+1];
 
-				counts[caller] += i->samplecount;
-				list.totalcount += i->samplecount;
+				counts[caller] += i.samplecount;
+				list.totalcount += i.samplecount;
 			}
 		}
 	}
@@ -502,7 +508,7 @@ Database::List Database::getCallers(const Database::Symbol *symbol) const
 		list.items.push_back(item);
 	}
 
-	return list;
+	return std::move(list);
 }
 
 Database::List Database::getCallees(const Database::Symbol *symbol) const

--- a/src/wxProfilerGUI/database.cpp
+++ b/src/wxProfilerGUI/database.cpp
@@ -4,6 +4,7 @@ Database.cpp
 
 Copyright (C) Nicholas Chapman
 Copyright (C) Richard Mitton
+Copyright (C) 2015 Ashod Nakashian
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -145,7 +146,7 @@ void Database::loadFromPath(const std::wstring& _profilepath, bool collapseOSCal
 	{
 		wxString name = entry->GetInternalName();
 
-		     if (name == "Symbols.txt")		loadSymbols(zip);
+			 if (name == "Symbols.txt")		loadSymbols(zip);
 		else if (name == "Callstacks.txt")	loadCallstacks(zip,collapseOSCalls);
 		else if (name == "IPCounts.txt")	loadIpCounts(zip);
 		else if (name == "Stats.txt")		loadStats(zip);
@@ -287,7 +288,7 @@ void Database::loadCallstacks(wxInputStream &file,bool collapseKernelCalls)
 						break;
 					callstack.addresses.erase(callstack.addresses.begin());
 				}
-                while (callstack.addresses.size() >= 2);
+				while (callstack.addresses.size() >= 2);
 			}
 		}
 
@@ -321,15 +322,15 @@ void Database::loadCallstacks(wxInputStream &file,bool collapseKernelCalls)
 		progressdlg.Update(0, "Filtering...");
 
 		std::vector<CallStack> filtered;
-        const auto total = callstacks.size();
+		const auto total = callstacks.size();
 		for (auto i = 0; i < total; ++i)
 		{
 			if (i % 256 == 0)
 				progressdlg.Update(kMaxProgress * i / total);
 
-            auto& item = callstacks[i];
+			auto& item = callstacks[i];
 			if (!filtered.empty() && filtered.back().addresses == item.addresses)
-                filtered.back().samplecount += item.samplecount;
+				filtered.back().samplecount += item.samplecount;
 			else
 				filtered.emplace_back(std::move(item));
 		}
@@ -407,16 +408,16 @@ void Database::scanMainList()
 		(int)callstacks.size(), theMainWin,
 		wxPD_APP_MODAL|wxPD_AUTO_HIDE);
 
-    mainList.items.clear();
-    mainList.items.reserve(symbols.size());
-    mainList.totalcount = 0;
+	mainList.items.clear();
+	mainList.items.reserve(symbols.size());
+	mainList.totalcount = 0;
 
 	Symbol::ID currentRootID = currentRoot ? currentRoot->id : -1;
 
 	int progress = 0;
 	for (auto& it = callstacks.begin(); it != callstacks.end(); ++it)
 	{
-        const auto& i = *it;
+		const auto& i = *it;
 		// Only use call stacks that include the current root
 		if (!includeCallstack(i)) continue;
 
@@ -426,13 +427,13 @@ void Database::scanMainList()
 		{
 			Symbol::ID id = i.symbols[n]->id;
 
-			// we filter out duplicates, to avoid getting funny numbers when 
+			// we filter out duplicates, to avoid getting funny numbers when
 			// using recursive functions.
 			if (!seen[id])
 			{
 				inclusive[id] += i.samplecount;
 				seen[id] = true;
-			} 
+			}
 			if (id == currentRootID) break;       // Stop handling the call stack if we encounter the root
 		}
 		mainList.totalcount += i.samplecount;
@@ -456,7 +457,7 @@ std::vector<const Database::CallStack*> Database::getCallstacksContaining(const 
 	std::vector<const CallStack *> ret;
 	for (auto& it = callstacks.begin(); it != callstacks.end(); ++it)
 	{
-        const auto& i = *it;
+		const auto& i = *it;
 		// Only use call stacks that include the current root
 		if (!includeCallstack(i)) continue;
 
@@ -479,7 +480,7 @@ Database::List Database::getCallers(const Database::Symbol *symbol) const
 	std::map<Address, double> counts;
 	for (auto& it = callstacks.begin(); it != callstacks.end(); ++it)
 	{
-        const auto& i = *it;
+		const auto& i = *it;
 		// Only use call stacks that include the current root
 		if (!includeCallstack(i)) continue;
 
@@ -516,7 +517,7 @@ Database::List Database::getCallees(const Database::Symbol *symbol) const
 	List list;
 	std::map<const Symbol *, double> counts;
 	for (auto i = callstacks.begin(); i != callstacks.end(); ++i)
-	{ 
+	{
 		// Only use call stacks that include the current root
 		if (!includeCallstack(*i)) continue;
 

--- a/src/wxProfilerGUI/profilergui.cpp
+++ b/src/wxProfilerGUI/profilergui.cpp
@@ -25,7 +25,6 @@ http://www.gnu.org/copyleft/gpl.html.
 #include <wx/mstream.h>
 #include <wx/apptrait.h>
 #include <wx/msw/apptrait.h>
-#include <memory>
 
 #include "threadpicker.h"
 #include "capturewin.h"
@@ -269,19 +268,26 @@ AttachInfo::~AttachInfo()
 		delete sym_info;
 }
 
+std::unique_ptr<AttachInfo> ProfilerGUI::CreateProfileeProcess(const std::wstring &run_cmd, const std::wstring &run_cwd, DWORD flags)
+{
+    STARTUPINFO si = { sizeof(si) };
+    PROCESS_INFORMATION pi = {};
+
+    std::vector<wchar_t> run_cmd_dup(run_cmd.size() + 1); // CreateProcess lpCommandLine must be mutable
+    std::copy(run_cmd.begin(), run_cmd.end(), run_cmd_dup.begin());
+    wenforce(CreateProcess(NULL, &run_cmd_dup[0], NULL, NULL, FALSE, flags, NULL, run_cwd.size() ? run_cwd.c_str() : NULL, &si, &pi), "CreateProcess");
+
+    std::unique_ptr<AttachInfo> output(new AttachInfo);
+    output->process_handle = pi.hProcess;
+    output->thread_handles.push_back(pi.hThread);
+    output->sym_info = new SymbolInfo;
+
+    return output;
+}
+
 AttachInfo *ProfilerGUI::RunProcess(const std::wstring &run_cmd, const std::wstring &run_cwd)
 {
-	STARTUPINFO si = {sizeof(si)};
-	PROCESS_INFORMATION pi = {};
-
-	std::vector<wchar_t> run_cmd_dup(run_cmd.size() + 1); // CreateProcess lpCommandLine must be mutable
-	std::copy(run_cmd.begin(), run_cmd.end(), run_cmd_dup.begin());
-	wenforce(CreateProcess( NULL, &run_cmd_dup[0], NULL, NULL, FALSE, 0, NULL, run_cwd.size() ? run_cwd.c_str() : NULL, &si, &pi ), "CreateProcess");
-
-	std::unique_ptr<AttachInfo> output(new AttachInfo);
-	output->process_handle = pi.hProcess;
-	output->thread_handles.push_back(pi.hThread);
-	output->sym_info = new SymbolInfo;
+    std::unique_ptr<AttachInfo> output = CreateProfileeProcess(run_cmd, run_cwd, 0);
 
 	// Load up the debug info for it.
 	// This can fail initially, because it turns out that you can't query information
@@ -303,6 +309,135 @@ AttachInfo *ProfilerGUI::RunProcess(const std::wstring &run_cmd, const std::wstr
 				throw;
 		}
 	}
+
+	return output.release();
+}
+AttachInfo *ProfilerGUI::RunProcessWithDebugger(const std::wstring &run_cmd, const std::wstring &run_cwd)
+{
+    std::unique_ptr<AttachInfo> output = CreateProfileeProcess(run_cmd, run_cwd, DEBUG_ONLY_THIS_PROCESS);
+
+    for (;;)
+    {
+        DEBUG_EVENT debugEvent;
+        WaitForDebugEvent(&debugEvent, INFINITE);
+        DWORD dwContinueStatus = DBG_CONTINUE;
+        switch (debugEvent.dwDebugEventCode)
+        {
+        case EXCEPTION_DEBUG_EVENT:
+            // Process the exception code. When handling
+            // exceptions, remember to set the continuation
+            // status parameter (dwContinueStatus). This value
+            // is used by the ContinueDebugEvent function.
+
+            switch (debugEvent.u.Exception.ExceptionRecord.ExceptionCode)
+            {
+            case EXCEPTION_ACCESS_VIOLATION:
+                // First chance: Pass this on to the system.
+                // Last chance: Display an appropriate error.
+                break;
+
+            case EXCEPTION_BREAKPOINT:
+                // First chance: Display the current
+                // instruction and register values.
+
+                // Once the debugee is fully loaded, we'll get
+                // a first-chance breakpoint exception.
+                // Perfect position to load symbols.
+                output->sym_info->loadSymbols(output->process_handle, false);
+                ContinueDebugEvent(debugEvent.dwProcessId,
+                                   debugEvent.dwThreadId,
+                                   dwContinueStatus);
+                //TODO: Must wait for further debug events or detatch.
+                return output.release();
+
+            case EXCEPTION_DATATYPE_MISALIGNMENT:
+                // First chance: Pass this on to the system.
+                // Last chance: Display an appropriate error.
+                break;
+
+            case EXCEPTION_SINGLE_STEP:
+                // First chance: Update the display of the
+                // current instruction and register values.
+                break;
+
+            case DBG_CONTROL_C:
+                // First chance: Pass this on to the system.
+                // Last chance: Display an appropriate error.
+                break;
+
+            default:
+                // Handle other exceptions.
+                break;
+            }
+
+            break;
+
+        case CREATE_THREAD_DEBUG_EVENT:
+            // As needed, examine or change the thread's registers
+            // with the GetThreadContext and SetThreadContext functions;
+            // and suspend and resume thread execution with the
+            // SuspendThread and ResumeThread functions.
+
+            //dwContinueStatus = OnCreateThreadDebugEvent(DebugEv);
+            break;
+
+        case CREATE_PROCESS_DEBUG_EVENT:
+            // As needed, examine or change the registers of the
+            // process's initial thread with the GetThreadContext and
+            // SetThreadContext functions; read from and write to the
+            // process's virtual memory with the ReadProcessMemory and
+            // WriteProcessMemory functions; and suspend and resume
+            // thread execution with the SuspendThread and ResumeThread
+            // functions. Be sure to close the handle to the process image
+            // file with CloseHandle.
+            //dwContinueStatus = OnCreateProcessDebugEvent(DebugEv);
+            CloseHandle(debugEvent.u.CreateProcessInfo.hFile);
+            break;
+
+        case EXIT_THREAD_DEBUG_EVENT:
+            // Display the thread's exit code.
+
+            //dwContinueStatus = OnExitThreadDebugEvent(DebugEv);
+            break;
+
+        case EXIT_PROCESS_DEBUG_EVENT:
+            // Display the process's exit code.
+
+            //dwContinueStatus = OnExitProcessDebugEvent(DebugEv);
+            break;
+
+        case LOAD_DLL_DEBUG_EVENT:
+            // Read the debugging information included in the newly
+            // loaded DLL. Be sure to close the handle to the loaded DLL
+            // with CloseHandle.
+
+            //dwContinueStatus = OnLoadDllDebugEvent(DebugEv);
+            CloseHandle(debugEvent.u.CreateProcessInfo.hFile);
+            break;
+
+        case UNLOAD_DLL_DEBUG_EVENT:
+            // Display a message that the DLL has been unloaded.
+
+            //dwContinueStatus = OnUnloadDllDebugEvent(DebugEv);
+            break;
+
+        case OUTPUT_DEBUG_STRING_EVENT:
+            // Display the output debugging string.
+
+            //dwContinueStatus = OnOutputDebugStringEvent(DebugEv);
+            break;
+
+        case RIP_EVENT:
+            //dwContinueStatus = OnRipEvent(DebugEv);
+            break;
+        }
+
+        // Resume executing the thread that reported the debugging event.
+
+        ContinueDebugEvent(debugEvent.dwProcessId,
+            debugEvent.dwThreadId,
+            dwContinueStatus);
+    }
 
 	return output.release();
 }
@@ -348,13 +483,21 @@ std::wstring ProfilerGUI::ObtainProfileData()
 			std::unique_ptr<AttachInfo> info;
 			try
 			{
-				info.reset(RunProcess(threadpicker->run_filename, threadpicker->run_cwd));
+                info.reset(RunProcessWithDebugger(threadpicker->run_filename, threadpicker->run_cwd));
 			}
-			catch (SleepyException &e)
+			catch (const SleepyException &e)
 			{
-				DestroyProgressWindow();
-				wxLogError("%ls\n", e.wwhat());
-				continue;
+                wxLogError("%ls\nWill retry using an alternative method.", e.wwhat());
+                try
+                {
+                    info.reset(RunProcess(threadpicker->run_filename, threadpicker->run_cwd));
+                }
+                catch (const SleepyException &e)
+                {
+                    DestroyProgressWindow();
+                    wxLogError("%ls\n", e.wwhat());
+                    continue;
+                }
 			}
 
 			wxScopeGuard sgTerm = wxMakeGuard(TerminateProcess, info->process_handle, 0);

--- a/src/wxProfilerGUI/profilergui.cpp
+++ b/src/wxProfilerGUI/profilergui.cpp
@@ -4,6 +4,7 @@ profilergui.cpp
 File created by ClassTemplate on Sun Mar 13 18:16:34 2005
 
 Copyright (C) Nicholas Chapman
+Copyright (C) 2015 Ashod Nakashian
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -75,7 +76,7 @@ ProfilerGUI::ProfilerGUI()
 {
 	initialized = false;
 	captureWin = NULL;
-    InitSysInfo();
+	InitSysInfo();
 }
 
 
@@ -271,31 +272,31 @@ AttachInfo::~AttachInfo()
 
 std::unique_ptr<AttachInfo> ProfilerGUI::CreateProfileeProcess(const std::wstring &run_cmd, const std::wstring &run_cwd, DWORD flags)
 {
-    STARTUPINFO si = { sizeof(si) };
-    PROCESS_INFORMATION pi = {};
+	STARTUPINFO si = { sizeof(si) };
+	PROCESS_INFORMATION pi = {};
 
-    std::vector<wchar_t> run_cmd_dup(run_cmd.size() + 1); // CreateProcess lpCommandLine must be mutable
-    std::copy(run_cmd.begin(), run_cmd.end(), run_cmd_dup.begin());
-    wenforce(CreateProcess(NULL, &run_cmd_dup[0], NULL, NULL, FALSE, flags, NULL, run_cwd.size() ? run_cwd.c_str() : NULL, &si, &pi), "CreateProcess");
+	std::vector<wchar_t> run_cmd_dup(run_cmd.size() + 1); // CreateProcess lpCommandLine must be mutable
+	std::copy(run_cmd.begin(), run_cmd.end(), run_cmd_dup.begin());
+	wenforce(CreateProcess(NULL, &run_cmd_dup[0], NULL, NULL, FALSE, flags, NULL, run_cwd.size() ? run_cwd.c_str() : NULL, &si, &pi), "CreateProcess");
 
-    if (!CanProfileProcess(pi.hProcess))
-    {
-        CloseHandle(pi.hThread);
-        CloseHandle(pi.hProcess);
-        throw SleepyException(L"Unsupported process. Cannot profile.");
-    }
+	if (!CanProfileProcess(pi.hProcess))
+	{
+		CloseHandle(pi.hThread);
+		CloseHandle(pi.hProcess);
+		throw SleepyException(L"Unsupported process. Cannot profile.");
+	}
 
-    std::unique_ptr<AttachInfo> output(new AttachInfo);
-    output->process_handle = pi.hProcess;
-    output->thread_handles.push_back(pi.hThread);
-    output->sym_info = new SymbolInfo;
+	std::unique_ptr<AttachInfo> output(new AttachInfo);
+	output->process_handle = pi.hProcess;
+	output->thread_handles.push_back(pi.hThread);
+	output->sym_info = new SymbolInfo;
 
-    return output;
+	return output;
 }
 
 AttachInfo *ProfilerGUI::RunProcess(const std::wstring &run_cmd, const std::wstring &run_cwd)
 {
-    std::unique_ptr<AttachInfo> output = CreateProfileeProcess(run_cmd, run_cwd, 0);
+	std::unique_ptr<AttachInfo> output = CreateProfileeProcess(run_cmd, run_cwd, 0);
 
 	// Load up the debug info for it.
 	// This can fail initially, because it turns out that you can't query information
@@ -323,130 +324,130 @@ AttachInfo *ProfilerGUI::RunProcess(const std::wstring &run_cmd, const std::wstr
 
 AttachInfo *ProfilerGUI::RunProcessWithDebugger(const std::wstring &run_cmd, const std::wstring &run_cwd)
 {
-    std::unique_ptr<AttachInfo> output = CreateProfileeProcess(run_cmd, run_cwd, DEBUG_ONLY_THIS_PROCESS);
+	std::unique_ptr<AttachInfo> output = CreateProfileeProcess(run_cmd, run_cwd, DEBUG_ONLY_THIS_PROCESS);
 
-    for (;;)
-    {
-        DEBUG_EVENT debugEvent;
-        WaitForDebugEvent(&debugEvent, INFINITE);
-        DWORD dwContinueStatus = DBG_CONTINUE;
-        switch (debugEvent.dwDebugEventCode)
-        {
-        case EXCEPTION_DEBUG_EVENT:
-            // Process the exception code. When handling
-            // exceptions, remember to set the continuation
-            // status parameter (dwContinueStatus). This value
-            // is used by the ContinueDebugEvent function.
+	for (;;)
+	{
+		DEBUG_EVENT debugEvent;
+		WaitForDebugEvent(&debugEvent, INFINITE);
+		DWORD dwContinueStatus = DBG_CONTINUE;
+		switch (debugEvent.dwDebugEventCode)
+		{
+		case EXCEPTION_DEBUG_EVENT:
+			// Process the exception code. When handling
+			// exceptions, remember to set the continuation
+			// status parameter (dwContinueStatus). This value
+			// is used by the ContinueDebugEvent function.
 
-            switch (debugEvent.u.Exception.ExceptionRecord.ExceptionCode)
-            {
-            case EXCEPTION_ACCESS_VIOLATION:
-                // First chance: Pass this on to the system.
-                // Last chance: Display an appropriate error.
-                break;
+			switch (debugEvent.u.Exception.ExceptionRecord.ExceptionCode)
+			{
+			case EXCEPTION_ACCESS_VIOLATION:
+				// First chance: Pass this on to the system.
+				// Last chance: Display an appropriate error.
+				break;
 
-            case EXCEPTION_BREAKPOINT:
-                // First chance: Display the current
-                // instruction and register values.
+			case EXCEPTION_BREAKPOINT:
+				// First chance: Display the current
+				// instruction and register values.
 
-                // Once the debugee is fully loaded, we'll get
-                // a first-chance breakpoint exception.
-                // Perfect position to load symbols.
-                output->sym_info->loadSymbols(output->process_handle, false);
-                ContinueDebugEvent(debugEvent.dwProcessId,
-                                   debugEvent.dwThreadId,
-                                   dwContinueStatus);
-                //TODO: Must wait for further debug events or detatch.
-                return output.release();
+				// Once the debugee is fully loaded, we'll get
+				// a first-chance breakpoint exception.
+				// Perfect position to load symbols.
+				output->sym_info->loadSymbols(output->process_handle, false);
+				ContinueDebugEvent(debugEvent.dwProcessId,
+								   debugEvent.dwThreadId,
+								   dwContinueStatus);
+				//TODO: Must wait for further debug events or detatch.
+				return output.release();
 
-            case EXCEPTION_DATATYPE_MISALIGNMENT:
-                // First chance: Pass this on to the system.
-                // Last chance: Display an appropriate error.
-                break;
+			case EXCEPTION_DATATYPE_MISALIGNMENT:
+				// First chance: Pass this on to the system.
+				// Last chance: Display an appropriate error.
+				break;
 
-            case EXCEPTION_SINGLE_STEP:
-                // First chance: Update the display of the
-                // current instruction and register values.
-                break;
+			case EXCEPTION_SINGLE_STEP:
+				// First chance: Update the display of the
+				// current instruction and register values.
+				break;
 
-            case DBG_CONTROL_C:
-                // First chance: Pass this on to the system.
-                // Last chance: Display an appropriate error.
-                break;
+			case DBG_CONTROL_C:
+				// First chance: Pass this on to the system.
+				// Last chance: Display an appropriate error.
+				break;
 
-            default:
-                // Handle other exceptions.
-                break;
-            }
+			default:
+				// Handle other exceptions.
+				break;
+			}
 
-            break;
+			break;
 
-        case CREATE_THREAD_DEBUG_EVENT:
-            // As needed, examine or change the thread's registers
-            // with the GetThreadContext and SetThreadContext functions;
-            // and suspend and resume thread execution with the
-            // SuspendThread and ResumeThread functions.
+		case CREATE_THREAD_DEBUG_EVENT:
+			// As needed, examine or change the thread's registers
+			// with the GetThreadContext and SetThreadContext functions;
+			// and suspend and resume thread execution with the
+			// SuspendThread and ResumeThread functions.
 
-            //dwContinueStatus = OnCreateThreadDebugEvent(DebugEv);
-            break;
+			//dwContinueStatus = OnCreateThreadDebugEvent(DebugEv);
+			break;
 
-        case CREATE_PROCESS_DEBUG_EVENT:
-            // As needed, examine or change the registers of the
-            // process's initial thread with the GetThreadContext and
-            // SetThreadContext functions; read from and write to the
-            // process's virtual memory with the ReadProcessMemory and
-            // WriteProcessMemory functions; and suspend and resume
-            // thread execution with the SuspendThread and ResumeThread
-            // functions. Be sure to close the handle to the process image
-            // file with CloseHandle.
-            //dwContinueStatus = OnCreateProcessDebugEvent(DebugEv);
-            CloseHandle(debugEvent.u.CreateProcessInfo.hFile);
-            break;
+		case CREATE_PROCESS_DEBUG_EVENT:
+			// As needed, examine or change the registers of the
+			// process's initial thread with the GetThreadContext and
+			// SetThreadContext functions; read from and write to the
+			// process's virtual memory with the ReadProcessMemory and
+			// WriteProcessMemory functions; and suspend and resume
+			// thread execution with the SuspendThread and ResumeThread
+			// functions. Be sure to close the handle to the process image
+			// file with CloseHandle.
+			//dwContinueStatus = OnCreateProcessDebugEvent(DebugEv);
+			CloseHandle(debugEvent.u.CreateProcessInfo.hFile);
+			break;
 
-        case EXIT_THREAD_DEBUG_EVENT:
-            // Display the thread's exit code.
+		case EXIT_THREAD_DEBUG_EVENT:
+			// Display the thread's exit code.
 
-            //dwContinueStatus = OnExitThreadDebugEvent(DebugEv);
-            break;
+			//dwContinueStatus = OnExitThreadDebugEvent(DebugEv);
+			break;
 
-        case EXIT_PROCESS_DEBUG_EVENT:
-            // Display the process's exit code.
+		case EXIT_PROCESS_DEBUG_EVENT:
+			// Display the process's exit code.
 
-            //dwContinueStatus = OnExitProcessDebugEvent(DebugEv);
-            break;
+			//dwContinueStatus = OnExitProcessDebugEvent(DebugEv);
+			break;
 
-        case LOAD_DLL_DEBUG_EVENT:
-            // Read the debugging information included in the newly
-            // loaded DLL. Be sure to close the handle to the loaded DLL
-            // with CloseHandle.
+		case LOAD_DLL_DEBUG_EVENT:
+			// Read the debugging information included in the newly
+			// loaded DLL. Be sure to close the handle to the loaded DLL
+			// with CloseHandle.
 
-            //dwContinueStatus = OnLoadDllDebugEvent(DebugEv);
-            CloseHandle(debugEvent.u.CreateProcessInfo.hFile);
-            break;
+			//dwContinueStatus = OnLoadDllDebugEvent(DebugEv);
+			CloseHandle(debugEvent.u.CreateProcessInfo.hFile);
+			break;
 
-        case UNLOAD_DLL_DEBUG_EVENT:
-            // Display a message that the DLL has been unloaded.
+		case UNLOAD_DLL_DEBUG_EVENT:
+			// Display a message that the DLL has been unloaded.
 
-            //dwContinueStatus = OnUnloadDllDebugEvent(DebugEv);
-            break;
+			//dwContinueStatus = OnUnloadDllDebugEvent(DebugEv);
+			break;
 
-        case OUTPUT_DEBUG_STRING_EVENT:
-            // Display the output debugging string.
+		case OUTPUT_DEBUG_STRING_EVENT:
+			// Display the output debugging string.
 
-            //dwContinueStatus = OnOutputDebugStringEvent(DebugEv);
-            break;
+			//dwContinueStatus = OnOutputDebugStringEvent(DebugEv);
+			break;
 
-        case RIP_EVENT:
-            //dwContinueStatus = OnRipEvent(DebugEv);
-            break;
-        }
+		case RIP_EVENT:
+			//dwContinueStatus = OnRipEvent(DebugEv);
+			break;
+		}
 
-        // Resume executing the thread that reported the debugging event.
+		// Resume executing the thread that reported the debugging event.
 
-        ContinueDebugEvent(debugEvent.dwProcessId,
-            debugEvent.dwThreadId,
-            dwContinueStatus);
-    }
+		ContinueDebugEvent(debugEvent.dwProcessId,
+			debugEvent.dwThreadId,
+			dwContinueStatus);
+	}
 
 	return output.release();
 }
@@ -492,22 +493,22 @@ std::wstring ProfilerGUI::ObtainProfileData()
 			std::unique_ptr<AttachInfo> info;
 			try
 			{
-                info.reset(RunProcessWithDebugger(threadpicker->run_filename, threadpicker->run_cwd));
+				info.reset(RunProcessWithDebugger(threadpicker->run_filename, threadpicker->run_cwd));
 			}
 			catch (const SleepyException &e)
 			{
-                wxLogError("%ls\nWill retry using an alternative method.", e.wwhat());
-                try
-                {
-                    info.reset(RunProcess(threadpicker->run_filename, threadpicker->run_cwd));
-                }
-                catch (const SleepyException &e)
-                {
-                    DestroyProgressWindow();
-                    wxLogError("%ls\n", e.wwhat());
-                    MessageBox(threadpicker->GetHWND(), std::wstring(L"Error: " + e.wwhat()).c_str(), L"Profiler Error", MB_OK);
-                    continue;
-                }
+				wxLogError("%ls\nWill retry using an alternative method.", e.wwhat());
+				try
+				{
+					info.reset(RunProcess(threadpicker->run_filename, threadpicker->run_cwd));
+				}
+				catch (const SleepyException &e)
+				{
+					DestroyProgressWindow();
+					wxLogError("%ls\n", e.wwhat());
+					MessageBox(threadpicker->GetHWND(), std::wstring(L"Error: " + e.wwhat()).c_str(), L"Profiler Error", MB_OK);
+					continue;
+				}
 			}
 
 			wxScopeGuard sgTerm = wxMakeGuard(TerminateProcess, info->process_handle, 0);

--- a/src/wxProfilerGUI/profilergui.h
+++ b/src/wxProfilerGUI/profilergui.h
@@ -40,6 +40,7 @@ http://www.gnu.org/copyleft/gpl.html.
 #include <string>
 #include <vector>
 #include <map>
+#include <memory>
 
 #include "../appinfo.h"
 
@@ -132,8 +133,11 @@ private:
 	void DestroyProgressWindow();
 
 	std::wstring LaunchProfiler(const AttachInfo *info);
-	AttachInfo *RunProcess(const std::wstring &run_cmd, const std::wstring &run_cwd);
-	void LoadProfileData(const std::wstring &filename);
+    std::unique_ptr<AttachInfo> CreateProfileeProcess(const std::wstring &run_cmd, const std::wstring &run_cwd, DWORD flags);
+    AttachInfo *RunProcessWithDebugger(const std::wstring &run_cmd, const std::wstring &run_cwd);
+    AttachInfo *RunProcess(const std::wstring &run_cmd, const std::wstring &run_cwd);
+
+    void LoadProfileData(const std::wstring &filename);
 	std::wstring ObtainProfileData();
 
 	class CaptureWin *captureWin;

--- a/src/wxProfilerGUI/profilergui.h
+++ b/src/wxProfilerGUI/profilergui.h
@@ -4,6 +4,7 @@ profilergui.h
 File created by ClassTemplate on Sun Mar 13 18:16:34 2005
 
 Copyright (C) Nicholas Chapman
+Copyright (C) 2015 Ashod Nakashian
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -133,11 +134,11 @@ private:
 	void DestroyProgressWindow();
 
 	std::wstring LaunchProfiler(const AttachInfo *info);
-    std::unique_ptr<AttachInfo> CreateProfileeProcess(const std::wstring &run_cmd, const std::wstring &run_cwd, DWORD flags);
-    AttachInfo *RunProcessWithDebugger(const std::wstring &run_cmd, const std::wstring &run_cwd);
-    AttachInfo *RunProcess(const std::wstring &run_cmd, const std::wstring &run_cwd);
+	std::unique_ptr<AttachInfo> CreateProfileeProcess(const std::wstring &run_cmd, const std::wstring &run_cwd, DWORD flags);
+	AttachInfo *RunProcessWithDebugger(const std::wstring &run_cmd, const std::wstring &run_cwd);
+	AttachInfo *RunProcess(const std::wstring &run_cmd, const std::wstring &run_cwd);
 
-    void LoadProfileData(const std::wstring &filename);
+	void LoadProfileData(const std::wstring &filename);
 	std::wstring ObtainProfileData();
 
 	class CaptureWin *captureWin;


### PR DESCRIPTION
A handful of improvements, most notably using the Debugger API to hook into the profilee before it starts running. This is useful for short-lived processes.

Also improved 64-bit detection and error reporting. In addition, a number of const-correctness and optimizations.

Willing to split them into separate PRs if that's more convenient.