### PR TITLE
Display timings on actual line numbers

### DIFF
--- a/src/profiler/profilerthread.cpp
+++ b/src/profiler/profilerthread.cpp
@@ -59,7 +59,7 @@ ProfilerThread::ProfilerThread(HANDLE target_process_, const std::vector<HANDLE>
 	numThreadsRunning = (int)target_threads.size();
 	status = L"Initializing";
 
-	filename = wxFileName::CreateTempFileName(wxEmptyString);
+	filename = wxFileName::CreateTempFileName(wxT("sleepy_"));
 }
 
 
@@ -235,10 +235,12 @@ void ProfilerThread::saveData()
 	for (auto i = used_addresses.begin(); i != used_addresses.end(); ++i)
 	{
 		int proclinenum;
+		int line;
 		std::wstring procfile;
 		PROFILER_ADDR addr = i->first;
 
 		const std::wstring proc_name = sym_info->getProcForAddr(addr, procfile, proclinenum);
+		sym_info->getLineForAddr(addr, procfile, line); // Get the real line number
 		txt << ::toHexString(addr);
 		txt << " ";
 		writeQuote(txt, sym_info->getModuleNameForAddr(addr));
@@ -246,6 +248,8 @@ void ProfilerThread::saveData()
 		writeQuote(txt, proc_name);
 		txt << " ";
 		writeQuote(txt, procfile);
+		txt << " ";
+		txt << ::toString(line);
 		txt << " ";
 		txt << ::toString(proclinenum);
 		txt << '\n';

--- a/src/wxProfilerGUI/database.cpp
+++ b/src/wxProfilerGUI/database.cpp
@@ -195,6 +195,7 @@ void Database::loadSymbols(wxInputStream &file)
 		::readQuote(stream, procname);
 		::readQuote(stream, sourcefilename);
 		stream >> info.sourceline;
+		stream >> info.procsourceline; // Line for the function
 		if (!inserted)
 		{
 			if (!warnedDupAddress)

--- a/src/wxProfilerGUI/database.h
+++ b/src/wxProfilerGUI/database.h
@@ -77,6 +77,7 @@ public:
 		// Symbol info
 		const Symbol *symbol;
 		unsigned      sourceline;
+		unsigned	  procsourceline;
 
 		// IP counts
 		double count;

--- a/src/wxProfilerGUI/mainwin.cpp
+++ b/src/wxProfilerGUI/mainwin.cpp
@@ -564,7 +564,7 @@ void MainWin::showSource( const Database::Symbol * symbol )
 	if (symbol->procname == L"KiFastSystemCallRet")
 		sourceview->showFile(L"[hint KiFastSystemCallRet]", 0, std::vector<double>());
 	else
-		sourceview->showFile(database->getFileName(symbol->sourcefile), database->getAddrInfo(symbol->address)->sourceline, linecounts);
+		sourceview->showFile(database->getFileName(symbol->sourcefile), database->getAddrInfo(symbol->address)->procsourceline, linecounts);
 }
 
 void MainWin::focusSymbol(const Database::Symbol *symbol)


### PR DESCRIPTION
Basically just displays the timings on the line numbers corresponding to the instructions, rather than the function's line number only.

(also bonus - temp files are named with sleepy_ prefix)