### PR TITLE
Added command-line option '/a' to profile an existing process

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ You can download an installer on [the project's website](http://www.codersnotes.
 * Update Wine DbgHelp for Windows
 * Contributed by [Bernat Muñoz Garcia](https://github.com/shashClp):
     * Use Scintilla for syntax highlighting
+* Added command-line option '/a' to profile an existing process by setting its process id
 
 ##### Version 0.90 (2014-12-23):
 

--- a/src/profiler/processinfo.cpp
+++ b/src/profiler/processinfo.cpp
@@ -25,6 +25,7 @@ http://www.gnu.org/copyleft/gpl.html..
 #include "processinfo.h"
 
 #include "../utils/osutils.h"
+#include "../utils/except.h"
 #include <windows.h>
 #include <tlhelp32.h>
 
@@ -119,4 +120,21 @@ void ProcessInfo::enumProcesses(std::vector<ProcessInfo>& processes_out)
 	}
 
 	CloseHandle(snapshot);
+}
+
+ProcessInfo ProcessInfo::FindProcessById(DWORD process_id)
+{
+	std::vector<ProcessInfo> allProcesses;
+	enumProcesses(allProcesses);
+	bool found = false;
+	for(int i =0;i< allProcesses.size();i++)
+	{
+		auto process = allProcesses[i];
+		if(process.getID() == process_id)
+		{
+			return process;
+			found = true;
+		}
+	}
+	throw SleepyException("Could not found process with specified id: " + std::to_string((unsigned long long) process_id));
 }

--- a/src/profiler/processinfo.h
+++ b/src/profiler/processinfo.h
@@ -48,7 +48,7 @@ public:
 
 
 	static void enumProcesses(std::vector<ProcessInfo>& processes_out);
-
+	static ProcessInfo FindProcessById(DWORD process_id);
 
 	std::vector<ThreadInfo> threads;
 

--- a/src/wxProfilerGUI/profilergui.h
+++ b/src/wxProfilerGUI/profilergui.h
@@ -133,6 +133,8 @@ private:
 
 	std::wstring LaunchProfiler(const AttachInfo *info);
 	AttachInfo *RunProcess(const std::wstring &run_cmd, const std::wstring &run_cwd);
+	AttachInfo *AttachToProcess(const std::wstring& processId);
+	static void TryLoadSymbols(AttachInfo* output);
 	void LoadProfileData(const std::wstring &filename);
 	std::wstring ObtainProfileData();
 


### PR DESCRIPTION
This option could be useful for automated profiling software that is already running.