### PR TITLE
Make it possible to profile processes with many threads

### DIFF
--- a/src/wxProfilerGUI/threadlist.cpp
+++ b/src/wxProfilerGUI/threadlist.cpp
@@ -30,6 +30,8 @@ http://www.gnu.org/copyleft/gpl.html.
 #include <wx/button.h>
 
 #define UPDATE_DELAY 1000	 // 1 second interval
+#define MAX_NUM_THREAD_LOCATIONS 100 // getting location of thread is very expensive, so only show it for the first X threads in the list
+#define MAX_NUM_DISPLAYED_THREADS 1000 // creating very large tables is expensive, limit number of threads to first X in selected sort order
 
 BEGIN_EVENT_TABLE(ThreadList, wxListCtrl)
 EVT_LIST_ITEM_SELECTED(THREADS_LIST, ThreadList::OnSelected)
@@ -201,10 +203,17 @@ void ThreadList::updateSorting()
 	fillList();
 }
 
+int ThreadList::getNumDisplayedThreads() {
+	int numThreads = (int) threads.size();
+	return numThreads < MAX_NUM_DISPLAYED_THREADS ? numThreads : MAX_NUM_DISPLAYED_THREADS;
+}
+
 void ThreadList::fillList()
 {
 	Freeze();
-	for(int i=0; i<(int)threads.size(); ++i)
+
+	int numDisplayedThreads = getNumDisplayedThreads();
+	for(int i=0; i<numDisplayedThreads; ++i)
 	{
 		char buf[32];
 		sprintf(buf, "%d", threads[i].getID());
@@ -236,7 +245,10 @@ void ThreadList::updateThreads(const ProcessInfo* processInfo, SymbolInfo *symIn
 		this->syminfo = symInfo;
 
 		this->threads = processInfo->threads;
-		for(int i=0; i<(int)this->threads.size(); ++i)
+		
+		
+		int numDisplayedThreads = getNumDisplayedThreads();
+		for(int i=0; i<numDisplayedThreads; ++i)
 		{
 			long tmp = this->InsertItem(i, "", -1);
 			SetItemData(tmp, i);
@@ -265,8 +277,7 @@ void ThreadList::updateTimes()
 		HANDLE thread_handle = this->threads[i].getThreadHandle(); 
 		if (thread_handle == NULL)
 			continue;
-
-		PROFILER_ADDR profaddr = 0;
+		
 		FILETIME CreationTime, ExitTime, KernelTime, UserTime;
 	
 		if ( GetThreadTimes(
@@ -287,58 +298,8 @@ void ThreadList::updateTimes()
 			}
 		}
 
-		try {
-			std::map<CallStack, SAMPLE_TYPE> callstacks;
-			std::map<PROFILER_ADDR, SAMPLE_TYPE> flatcounts;
-			Profiler profiler(process_handle, thread_handle, callstacks, flatcounts);
-			bool ok = profiler.sampleTarget(0, syminfo);
-			if (ok && !profiler.targetExited() && callstacks.size() > 0)
-			{
-				const CallStack &stack = callstacks.begin()->first;
-				profaddr = stack.addr[0];
-
-				// Collapse functions down
-				if (syminfo && stack.depth > 0)
-				{
-					for (size_t n=0;n<stack.depth;n++)
-					{
-						PROFILER_ADDR addr = stack.addr[n];
-						std::wstring mod = syminfo->getModuleNameForAddr(addr);
-						if (IsOsModule(mod))
-						{
-							profaddr = addr;
-						} else {
-							break;
-						}
-					}
-
-					for (int n=(int)stack.depth-1;n>=0;n--)
-					{
-						std::wstring file;
-						int line;
-
-						PROFILER_ADDR addr = stack.addr[n];
-						std::wstring loc = syminfo->getProcForAddr(addr, file, line);
-						if (IsOsFunction(loc))
-						{
-							profaddr = addr;
-							break;
-						}
-					}
-				}
-			}
-		} catch( ProfilerExcep &)
-		{
-		}
-
-		if (profaddr && syminfo)
-		{
-			std::wstring file;
-			int line;
-			
-			// Grab the name of the current IP location.
-			std::wstring loc = syminfo->getProcForAddr(profaddr, file, line);
-			
+		if (i < MAX_NUM_THREAD_LOCATIONS) {
+			std::wstring loc = getLocation(thread_handle);
 			this->threads[i].setLocation(loc);
 		}
 	}
@@ -346,4 +307,60 @@ void ThreadList::updateTimes()
 	fillList();
 }
 
+std::wstring ThreadList::getLocation(HANDLE thread_handle) {
+	PROFILER_ADDR profaddr = 0;
+	try {
+		std::map<CallStack, SAMPLE_TYPE> callstacks;
+		std::map<PROFILER_ADDR, SAMPLE_TYPE> flatcounts;
+		Profiler profiler(process_handle, thread_handle, callstacks, flatcounts);
+		bool ok = profiler.sampleTarget(0, syminfo);
+		if (ok && !profiler.targetExited() && callstacks.size() > 0)
+		{
+			const CallStack &stack = callstacks.begin()->first;
+			profaddr = stack.addr[0];
 
+			// Collapse functions down
+			if (syminfo && stack.depth > 0)
+			{
+				for (size_t n=0;n<stack.depth;n++)
+				{
+					PROFILER_ADDR addr = stack.addr[n];
+					std::wstring mod = syminfo->getModuleNameForAddr(addr);
+					if (IsOsModule(mod))
+					{
+						profaddr = addr;
+					} else {
+						break;
+					}
+				}
+
+				for (int n=(int)stack.depth-1;n>=0;n--)
+				{
+					std::wstring file;
+					int line;
+
+					PROFILER_ADDR addr = stack.addr[n];
+					std::wstring loc = syminfo->getProcForAddr(addr, file, line);
+					if (IsOsFunction(loc))
+					{
+						profaddr = addr;
+						break;
+					}
+				}
+			}
+		}
+	} catch( ProfilerExcep &)
+	{
+	}
+
+	if (profaddr && syminfo)
+	{
+		std::wstring file;
+		int line;
+			
+		// Grab the name of the current IP location.
+		return syminfo->getProcForAddr(profaddr, file, line);
+	}
+
+	return L"-";
+}

--- a/src/wxProfilerGUI/threadlist.h
+++ b/src/wxProfilerGUI/threadlist.h
@@ -85,6 +85,8 @@ private:
 	wxButton *all_button;
 
 	void fillList();
+	int getNumDisplayedThreads();
+	std::wstring getLocation(HANDLE thread_handle);
 };
 
 


### PR DESCRIPTION
Limit number of displayed threads to 1000. This is currently hardcoded. Could be improved to a user changeable option in the future.

Limit number of threads that get live updates of location every second. The limit is currently 100 and hardcoded. Could be improved to a user changeable option in the future.

Without those two changes the UI almost freezes completely when trying to profile a process with 1000 threads or more.