### PR TITLE
Added Callgrind format file export feature

### DIFF
--- a/src/wxProfilerGUI/mainwin.h
+++ b/src/wxProfilerGUI/mainwin.h
@@ -65,6 +65,7 @@ public:
 
 	void OnSaveAs(wxCommandEvent& event);
 	void OnExportAsCsv(wxCommandEvent& event);
+	void OnExportAsCallgrind(wxCommandEvent& event);
 	void OnLoadMinidumpSymbols(wxCommandEvent& event);
 	void OnCollapseOS(wxCommandEvent& event);
 	void OnStats(wxCommandEvent& event);


### PR DESCRIPTION
This adds a new file export feature to the File menu below the CSV exporter. The [Callgrind Format](http://valgrind.org/docs/manual/cl-format.html) can be visualized graphically in [QCachegrind](https://sourceforge.net/projects/qcachegrindwin/) (QT version of [KCachegrind](http://kcachegrind.sourceforge.net/html/Home.html) which runs on Windows).

Due to the nature of sample profiling the exported call counts aren't available, so this exporter just writes the number of callstacks containing a call instead. But with the timings and caller/callee relationships it still is quite useful and fun to look at :-)

I tried to do like the code around me does but wanted to contain this new feature in one block thus the inline struct with the static helper functions. Feel free to request style changes.

| Example Visualization | Example Visualization |
|:---:|:---:|
| [<img src="https://pbs.twimg.com/media/DDgAmNxUAAEvxCS.png:thumb">](https://pbs.twimg.com/media/DDgAmNxUAAEvxCS.png:orig) | [<img src="https://pbs.twimg.com/media/DDgAnB4U0AACbO5.png:thumb">](https://pbs.twimg.com/media/DDgAnB4U0AACbO5.png:orig) |