### PR TITLE
Added command-line option '/amt' and '/ambt' to profile an existing process's certain thread by setting its process id

### DIFF
--- a/src/profiler/threadinfo.cpp
+++ b/src/profiler/threadinfo.cpp
@@ -1,4 +1,4 @@
-/*=====================================================================
+﻿/*=====================================================================
 threadinfo.cpp
 --------------
 File created by ClassTemplate on Sun Mar 20 03:22:37 2005
@@ -23,8 +23,17 @@ http://www.gnu.org/copyleft/gpl.html..
 =====================================================================*/
 #include "threadinfo.h"
 
+static __int64 getDiff(FILETIME before, FILETIME after)
+{
+	__int64 i0 = (__int64(before.dwHighDateTime) << 32) + before.dwLowDateTime;
+	__int64 i1 = (__int64(after.dwHighDateTime) << 32) + after.dwLowDateTime;
+	return i1 - i0;
+}
 
-
+static __int64 getTotal(FILETIME time)
+{
+	return (__int64(time.dwHighDateTime) << 32) + time.dwLowDateTime;
+}
 
 // DE: 20090325 Threads now have CPU usage
 ThreadInfo::ThreadInfo(DWORD id_, HANDLE thread_handle_)
@@ -39,4 +48,38 @@ ThreadInfo::ThreadInfo(DWORD id_, HANDLE thread_handle_)
 
 ThreadInfo::~ThreadInfo()
 {
+}
+
+bool ThreadInfo::recalcUsage(int sampleTimeDiff)
+{
+	cpuUsage = -1;
+	totalCpuTimeMs = -1;
+
+	HANDLE thread_handle = getThreadHandle();
+	if (thread_handle == NULL)
+		return false;
+
+	FILETIME CreationTime, ExitTime, KernelTime, UserTime;
+
+	if (!GetThreadTimes(
+		thread_handle,
+		&CreationTime,
+		&ExitTime,
+		&KernelTime,
+		&UserTime
+	))
+		return false;
+	
+	__int64 kernel_diff = getDiff(prevKernelTime, KernelTime);
+	__int64 user_diff = getDiff(prevUserTime, UserTime);
+	prevKernelTime = KernelTime;
+	prevUserTime = UserTime;
+
+	if (sampleTimeDiff > 0) {
+		__int64 total_diff = ((kernel_diff + user_diff) / 10000) * 100;
+		cpuUsage = static_cast<int>(total_diff / sampleTimeDiff);
+	}
+	totalCpuTimeMs = (getTotal(KernelTime) + getTotal(UserTime)) / 10000;
+
+	return true;
 }

--- a/src/profiler/threadinfo.h
+++ b/src/profiler/threadinfo.h
@@ -1,4 +1,4 @@
-/*=====================================================================
+﻿/*=====================================================================
 threadinfo.h
 ------------
 File created by ClassTemplate on Sun Mar 20 03:22:37 2005
@@ -51,6 +51,8 @@ public:
 
 	const std::wstring& getLocation() const { return location; }
 	void setLocation(const std::wstring &loc) { location = loc; }
+
+	bool recalcUsage(int sampleTimeDiff);
 
 	FILETIME prevKernelTime, prevUserTime;
 	// DE: 20090325 Threads now have CPU usage

--- a/src/wxProfilerGUI/mainwin.cpp
+++ b/src/wxProfilerGUI/mainwin.cpp
@@ -1,4 +1,4 @@
-/*=====================================================================
+﻿/*=====================================================================
 mainwin.cpp
 -----------
 File created by ClassTemplate on Sun Mar 13 21:12:40 2005
@@ -491,8 +491,10 @@ void MainWin::OnExportAsCallgrind(wxCommandEvent& WXUNUSED(event))
 			selfCostLines.clear();
 			childCost_SampleCounts.clear();
 			childCost_CallCounts.clear();
-			for each (const Database::CallStack* callstack in database->getCallstacksContaining(symbol))
+			auto callstacks = database->getCallstacksContaining(symbol);
+			for (auto it = callstacks.begin(); it != callstacks.end(); ++it)
 			{
+				const Database::CallStack* callstack = *it;
 				for (size_t i=0, callstackCount=callstack->addresses.size(), callstackTop=callstackCount-1; i<callstackCount; i++)
 				{
 					const Database::AddrInfo* addrinfo = database->getAddrInfo(callstack->addresses[i]);

--- a/src/wxProfilerGUI/profilergui.h
+++ b/src/wxProfilerGUI/profilergui.h
@@ -1,4 +1,4 @@
-/*=====================================================================
+﻿/*=====================================================================
 profilergui.h
 -------------
 File created by ClassTemplate on Sun Mar 13 18:16:34 2005
@@ -141,6 +141,8 @@ private:
 	std::wstring LaunchProfiler(const AttachInfo *info);
 	AttachInfo *RunProcess(const std::wstring &run_cmd, const std::wstring &run_cwd);
 	AttachInfo *AttachToProcess(const std::wstring& processId);
+	AttachInfo *AttachToMainThread(const std::wstring& processId);
+	AttachInfo *AttachToMostBusyThread(const std::wstring& processId);
 	static void TryLoadSymbols(AttachInfo* output);
 	void LoadProfileData(const std::wstring &filename);
 	std::wstring ObtainProfileData();


### PR DESCRIPTION
'/amt' is an option to profile "main thread".
And '/ambt' is an option to profile "most busy thread".

These were added because I needed.
But it may helpful to someone else, so I open a pull request. 
please consider this request.
