### PR TITLE
Added command-line switch '/mt' and '/mbt'

### DIFF
--- a/src/profiler/threadinfo.h
+++ b/src/profiler/threadinfo.h
@@ -1,4 +1,4 @@
-/*=====================================================================
+﻿/*=====================================================================
 threadinfo.h
 ------------
 File created by ClassTemplate on Sun Mar 20 03:22:37 2005
@@ -51,6 +51,8 @@ public:
 
 	const std::wstring& getLocation() const { return location; }
 	void setLocation(const std::wstring &loc) { location = loc; }
+
+	bool recalcUsage(int sampleTimeDiff);
 
 	FILETIME prevKernelTime, prevUserTime;
 	// DE: 20090325 Threads now have CPU usage

--- a/src/wxProfilerGUI/profilergui.cpp
+++ b/src/wxProfilerGUI/profilergui.cpp
@@ -1,4 +1,4 @@
-/*=====================================================================
+﻿/*=====================================================================
 profilergui.cpp
 ---------------
 File created by ClassTemplate on Sun Mar 13 18:16:34 2005
@@ -66,6 +66,8 @@ static const wxCmdLineEntryDesc g_cmdLineDesc[] =
 	{ wxCMD_LINE_SWITCH, "q", "", "Quiet mode (no error messages will be shown).",			wxCMD_LINE_VAL_NONE },
 	{ wxCMD_LINE_SWITCH, "", "wine", "Use Wine DbgHelp.",									wxCMD_LINE_VAL_NONE },
 	{ wxCMD_LINE_SWITCH, "", "mingw", "Use Dr. MinGW DbgHelp.",							wxCMD_LINE_VAL_NONE },
+	{ wxCMD_LINE_SWITCH, "mt", "", "When attaching a process, profiles only main thread.",			wxCMD_LINE_VAL_NONE },
+	{ wxCMD_LINE_SWITCH, "mbt", "", "When attaching a process, profiles only most busy thread.",	wxCMD_LINE_VAL_NONE },
 	{ wxCMD_LINE_PARAM, NULL, NULL, "Loads an existing profile from a file.",				wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL},
 
 	{ wxCMD_LINE_NONE }
@@ -300,6 +302,51 @@ AttachInfo *ProfilerGUI::RunProcess(const std::wstring &run_cmd, const std::wstr
 	return output.release();
 }
 
+static HANDLE getMostBusyThread(ProcessInfo& process_info)
+{
+	int max = -1;
+	HANDLE mostBusy = NULL;
+	for (auto thread_info = process_info.threads.begin(); thread_info != process_info.threads.end(); ++thread_info)
+	{
+		thread_info->recalcUsage(0);
+		if (max < thread_info->totalCpuTimeMs)
+		{
+			max = thread_info->totalCpuTimeMs;
+			mostBusy = thread_info->getThreadHandle();
+		}
+	}
+
+	return mostBusy;
+}
+
+static std::vector<HANDLE> getThreadsByAttachMode(ProcessInfo& process_info)
+{
+	std::vector<HANDLE> threadHandles;
+
+	if (process_info.threads.empty())
+		return threadHandles;
+
+	switch (prefs.attachMode)
+	{
+	case ATTACH_MAIN_THREAD:
+		threadHandles.push_back(process_info.threads.front().getThreadHandle());
+		return threadHandles;
+
+	case ATTACH_MOST_BUSY_THREAD:
+		if (HANDLE mostBusy = getMostBusyThread(process_info))
+			threadHandles.push_back(mostBusy);
+		return threadHandles;
+
+	default: // all thread
+		threadHandles.reserve(process_info.threads.size());
+		for (auto thread_info = process_info.threads.begin(); thread_info != process_info.threads.end(); ++thread_info)
+		{
+			threadHandles.push_back(thread_info->getThreadHandle());
+		}
+		return threadHandles;
+	}
+}
+
 AttachInfo * ProfilerGUI::AttachToProcess(const std::wstring& processId)
 {
 	DWORD processId_dw;
@@ -314,10 +361,7 @@ AttachInfo * ProfilerGUI::AttachToProcess(const std::wstring& processId)
 	ProcessInfo process_info = ProcessInfo::FindProcessById(processId_dw);
 	AttachInfo* attach_info =new AttachInfo();
 	attach_info->process_handle = process_info.getProcessHandle();
-	for(auto thread_info = process_info.threads.begin(); thread_info!= process_info.threads.end(); ++thread_info)
-	{
-		attach_info->thread_handles.push_back(thread_info->getThreadHandle());
-	}
+	attach_info->thread_handles = getThreadsByAttachMode(process_info);
 	attach_info->sym_info = new SymbolInfo();
 
 	TryLoadSymbols(attach_info);
@@ -577,6 +621,10 @@ bool ProfilerGUI::OnCmdLineParsed(wxCmdLineParser& parser)
 		prefs.useWineSwitch = true;
 	if (parser.Found("mingw"))
 		prefs.useMingwSwitch = true;
+	if (parser.Found("mt", &param))
+		prefs.attachMode = ATTACH_MAIN_THREAD;
+	if (parser.Found("mbt", &param))
+		prefs.attachMode = ATTACH_MOST_BUSY_THREAD;
 
 	return true;
 }

--- a/src/wxProfilerGUI/profilergui.h
+++ b/src/wxProfilerGUI/profilergui.h
@@ -1,4 +1,4 @@
-/*=====================================================================
+﻿/*=====================================================================
 profilergui.h
 -------------
 File created by ClassTemplate on Sun Mar 13 18:16:34 2005
@@ -45,6 +45,13 @@ extern wxIcon sleepy_icon;
 
 class SymbolInfo;
 
+enum AttachMode
+{
+	ATTACH_ALL_THREAD,	// default
+	ATTACH_MAIN_THREAD,
+	ATTACH_MOST_BUSY_THREAD,
+};
+
 struct AttachInfo
 {
 	AttachInfo();
@@ -67,6 +74,7 @@ public:
 		saveMinidump = -1;
 		throttle = 100;
 		useWinePref = useWineSwitch = useMingwSwitch = false;
+		attachMode = ATTACH_ALL_THREAD;
 	}
 
 	wxString symSearchPath;
@@ -77,6 +85,7 @@ public:
 	int throttle;
 
 	bool useWinePref, useWineSwitch, useMingwSwitch;
+	AttachMode attachMode;
 
 	bool UseWine()
 	{


### PR DESCRIPTION
'/mt' and '/mbt' are switches to select `AttachMode` when attaching a process by using an '/a' option.
'/mt' is an option to profile "main thread".
And '/mbt' is an option to profile "most busy thread".

This pull request is refactored from #47 on a new branch.
Thanks for your kind review.