### PR TITLE
Unload symbols (PDB files) after profiling by attaching

### DIFF
--- a/src/wxProfilerGUI/threadpicker.cpp
+++ b/src/wxProfilerGUI/threadpicker.cpp
@@ -85,7 +85,7 @@ void symLogCallback(const wchar_t *text)
 ThreadPicker::ThreadPicker()
 :	wxModalFrame(NULL, -1, wxString(APPNAME),
 			 wxDefaultPosition, wxDefaultSize,
-			 wxDEFAULT_FRAME_STYLE)
+			 wxDEFAULT_FRAME_STYLE), attach_info(NULL)
 {
 	SetIcon(sleepy_icon);
 
@@ -314,6 +314,8 @@ ThreadPicker::~ThreadPicker()
 {
 	g_symLog = NULL;
 	delete log;
+	if (attach_info)
+		delete attach_info;
 }
 
 /*


### PR DESCRIPTION
When profiling not by loading a .sleepy file but by attaching to the process from the ThreadPicker the attach_info member gets allocated with `new AttachInfo` and never gets deleted even after the ThreadPicker gets deleted.

This causes the symbols (PDB files) to be locked forever until Very Sleepy is closed. This makes it annoying to test code changes while keeping multiple profile runs open because a program can't be recompiled while its PDB file is locked.