### PR TITLE
Jump to the correct source line as shown in list views

### DIFF
--- a/src/wxProfilerGUI/CallstackView.cpp
+++ b/src/wxProfilerGUI/CallstackView.cpp
@@ -106,8 +106,8 @@ void CallstackView::OnSelected(wxListEvent& event)
 	itemSelected = event.m_itemIndex;
 	if (callstackActive < callstacks.size() && (size_t)itemSelected < callstacks[callstackActive]->symbols.size())
 	{
-		const Database::Symbol *symbol = callstacks[callstackActive]->symbols[itemSelected];
-		theMainWin->focusSymbol(symbol);
+		const Database::AddrInfo *addrinfo = database->getAddrInfo(callstacks[callstackActive]->addresses[itemSelected]);
+		theMainWin->focusSymbol(addrinfo);
 	}
 	itemSelected = ~0u;
 }
@@ -199,6 +199,7 @@ void CallstackView::updateList()
 	{
 		const Database::Symbol *snow = now->symbols[i];
 		Database::Address addr = now->addresses[i];
+		const Database::AddrInfo *addrinfo = database->getAddrInfo(addr);
 
 		if (i == (size_t)listCtrl->GetItemCount())
 			listCtrl->InsertItem(i,snow->procname.c_str());
@@ -217,7 +218,7 @@ void CallstackView::updateList()
 
 		listCtrl->SetItem(i, COL_MODULE    , database->getModuleName(snow->module));
 		listCtrl->SetItem(i, COL_SOURCEFILE, database->getFileName  (snow->sourcefile));
-		listCtrl->SetItem(i, COL_SOURCELINE, wxString::Format("%d", database->getAddrInfo(addr)->sourceline));
+		listCtrl->SetItem(i, COL_SOURCELINE, wxString::Format("%d", addrinfo->sourceline));
 		listCtrl->SetItem(i, COL_ADDRESS   , ::toHexString(addr));
 
 		wxFont font = listCtrl->GetFont();
@@ -232,8 +233,7 @@ void CallstackView::updateList()
 		} else {
 			listCtrl->SetItemState(i, 0, wxLIST_STATE_FOCUSED|wxLIST_STATE_SELECTED);
 		}
-		// On x64, wx will downcast this to 32-bit unless it's a pointer.
-		listCtrl->SetItemPtrData(i, snow->address);
+		listCtrl->SetItemPtrData(i, (wxUIntPtr)addrinfo);
 	}
 
 	while (listCtrl->GetItemCount() > int(now->symbols.size()))

--- a/src/wxProfilerGUI/contextmenu.cpp
+++ b/src/wxProfilerGUI/contextmenu.cpp
@@ -121,8 +121,9 @@ void FunctionMenu(wxListCtrl *list, Database *database)
 		long i = list->GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_FOCUSED);
 		if (i < 0)
 			return;
-		addr = list->GetItemData(i);
-		sym = database->getAddrInfo(addr)->symbol;
+		const Database::AddrInfo *addrinfo = (const Database::AddrInfo *)list->GetItemData(i);
+		sym = addrinfo->symbol;
+		addr = sym->address;
 	}
 
 	for (long item = -1;;)
@@ -133,7 +134,8 @@ void FunctionMenu(wxListCtrl *list, Database *database)
 		if (item == -1)
 			break;
 
-		selection.push_back(list->GetItemData(item));
+		const Database::AddrInfo *itemaddrinfo = (const Database::AddrInfo *)list->GetItemData(item);
+		selection.push_back(itemaddrinfo->symbol->address);
 	}
 
 	if (selection.size() == 0)

--- a/src/wxProfilerGUI/mainwin.h
+++ b/src/wxProfilerGUI/mainwin.h
@@ -103,13 +103,13 @@ public:
 	/// Switch selection to a given symbol.
 	/// Does not repopulate the secondary views.
 	/// Called when clicking on a particular symbol.
-	void focusSymbol(const Database::Symbol *symbol);
+	void focusSymbol(const Database::AddrInfo *addrinfo);
 
 	/// Inspect a given symbol.
 	/// Opens the corresponding symbol properties in all related views.
 	/// Implies focusSymbol(symbol).
 	/// Called when double-clicking on a particular symbol.
-	void inspectSymbol(const Database::Symbol *symbol, bool addtohistory=true);
+	void inspectSymbol(const Database::AddrInfo *addrinfo, bool addtohistory=true);
 
 	/// Called by SourceView to update the status bar.
 	void setSourcePos(const std::wstring& currentfile, int currentline);
@@ -156,7 +156,7 @@ private:
 
 	ViewState viewstate;
 
-	std::deque<Database::Address> history;
+	std::deque<const Database::AddrInfo*> history;
 	size_t historyPos;
 
 	wxGauge *gauge;
@@ -169,7 +169,7 @@ private:
 	/// Called when the symbol strings have changed in one way or another.
 	void symbolsChanged();
 
-	void showSource(const Database::Symbol * symbol);
+	void showSource(const Database::AddrInfo *addrinfo);
 
 	void updateStatusBar();
 };


### PR DESCRIPTION
- Applies to 'Called From' and 'Call Stacks' view where the line numbers are not the procedure entry points
- Makes multiple entries of the same function in the 'Called From' jump to the correct source line
- Keep the correct line number reference in the Back/Forward history
- This also fixes viewing 64bit process profile .sleepy files in the 32bit version (avoid 64bit ptr to long cast)

This is mostly for convenience because I find it unintuitive to (single) click through the entries in the 'Called From' list and have it jump not to the line of the actual call. Fixing that also lead to fixing crashes when loading a 64bit process profile .sleepy file in the 32bit version.