### PR TITLE
Show thread name on threads list, if available.

### DIFF
--- a/src/profiler/threadinfo.cpp
+++ b/src/profiler/threadinfo.cpp
@@ -35,6 +35,14 @@ static __int64 getTotal(FILETIME time)
 	return (__int64(time.dwHighDateTime) << 32) + time.dwLowDateTime;
 }
 
+typedef HRESULT( WINAPI *Fn )(HANDLE, PWSTR*);
+static Fn GetThreadDescription = reinterpret_cast<Fn>(GetProcAddress( GetModuleHandle( TEXT( "Kernel32.dll" ) ), "GetThreadDescription" ));
+
+bool hasThreadDescriptionAPI()
+{
+	// Helper function to let main window decide whether to hide this column
+	return GetThreadDescription != NULL;
+}
 
 // DE: 20090325 Threads now have CPU usage
 ThreadInfo::ThreadInfo(DWORD id_, HANDLE thread_handle_)
@@ -42,10 +50,21 @@ ThreadInfo::ThreadInfo(DWORD id_, HANDLE thread_handle_)
 {
 	prevKernelTime.dwHighDateTime = prevKernelTime.dwLowDateTime = 0;
 	prevUserTime.dwHighDateTime = prevUserTime.dwLowDateTime = 0;
-  cpuUsage = -1;
+	cpuUsage = -1;
 
+	name = L"-";
+
+	// Try to use the new thread naming API from Win10 Creators update onwards if we have it
+	if (GetThreadDescription) {
+		PWSTR data;
+		HRESULT hr = GetThreadDescription(thread_handle, &data);
+		if (SUCCEEDED( hr )) {
+			if (wcslen(data) > 0)
+				name = data;
+			LocalFree(data);
+		}
+	}
 }
-
 
 ThreadInfo::~ThreadInfo()
 {

--- a/src/profiler/threadinfo.cpp
+++ b/src/profiler/threadinfo.cpp
@@ -35,8 +35,8 @@ static __int64 getTotal(FILETIME time)
 	return (__int64(time.dwHighDateTime) << 32) + time.dwLowDateTime;
 }
 
-typedef HRESULT( WINAPI *Fn )(HANDLE, PWSTR*);
-static Fn GetThreadDescription = reinterpret_cast<Fn>(GetProcAddress( GetModuleHandle( TEXT( "Kernel32.dll" ) ), "GetThreadDescription" ));
+typedef HRESULT( WINAPI *GetThreadDescriptionFunc )(HANDLE, PWSTR*);
+static GetThreadDescriptionFunc GetThreadDescription = reinterpret_cast<GetThreadDescriptionFunc>(GetProcAddress( GetModuleHandle( TEXT( "Kernel32.dll" ) ), "GetThreadDescription" ));
 
 bool hasThreadDescriptionAPI()
 {

--- a/src/profiler/threadinfo.h
+++ b/src/profiler/threadinfo.h
@@ -28,6 +28,7 @@ http://www.gnu.org/copyleft/gpl.html..
 #include <windows.h>
 #include <string>
 
+bool hasThreadDescriptionAPI();
 
 /*=====================================================================
 ThreadInfo
@@ -52,6 +53,7 @@ public:
 	const std::wstring& getLocation() const { return location; }
 	void setLocation(const std::wstring &loc) { location = loc; }
 
+	const std::wstring& getName() const { return name; }
 	bool recalcUsage(int sampleTimeDiff);
 
 	FILETIME prevKernelTime, prevUserTime;
@@ -61,6 +63,7 @@ public:
 
 private:
 	std::wstring location;
+	std::wstring name;
 	DWORD id;
 	HANDLE thread_handle;
 };

--- a/src/wxProfilerGUI/threadlist.cpp
+++ b/src/wxProfilerGUI/threadlist.cpp
@@ -390,4 +390,3 @@ std::wstring ThreadList::getLocation(HANDLE thread_handle) {
 
 	return L"-";
 }
-

--- a/src/wxProfilerGUI/threadlist.h
+++ b/src/wxProfilerGUI/threadlist.h
@@ -62,6 +62,7 @@ public:
 	void sortByCpuUsage();
 	void sortByTotalCpuTime();
 	void sortByID();
+	void sortByName();
 
 	std::vector<const ThreadInfo*> getSelectedThreads(bool all=false);
 private:
@@ -72,6 +73,7 @@ private:
 		COL_CPUUSAGE,
 		COL_TOTALCPU,
 		COL_ID,
+		COL_NAME,
 		NUM_COLUMNS
 	};
 
@@ -89,6 +91,7 @@ private:
 	void fillList();
 	int getNumDisplayedThreads();
 	std::wstring getLocation(HANDLE thread_handle);
+	std::wstring getName(HANDLE thread_handle);
 };
 
 


### PR DESCRIPTION
Find if GetThreadDescription() is available in Kernel32.dll (it's available from the Win10 Creators update onwards). If it is, add another column "Thread Name" to the list of threads shown when selecting which thread(s) to profile. If this function is unavailable, don't show this extra column at all. If it is available, we rely on the application being profiled to have called SetThreadDescription(), but if it has not, we just show "-" instead.