### PR TITLE
Bug fix(es); Add cmdline parameter to sample a specific thread or set of threads; Code Cleanup; update build scripts

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -107,10 +107,12 @@ if not %CONFIGURATION% == Release goto :eof
 rem Find InnoSetup
 
 if not defined INNOSETUP for %%a in (ISCC.exe) do if not [%%~$PATH:a] == [] set INNOSETUP="%%~$PATH:a"
-if not defined INNOSETUP if exist "%ProgramFiles%\Inno Setup 5\ISCC.exe" set INNOSETUP="%ProgramFiles%\Inno Setup 5\ISCC.exe"
-if not defined INNOSETUP if exist "%ProgramFiles(x86)%\Inno Setup 5\ISCC.exe" set INNOSETUP="%ProgramFiles(x86)%\Inno Setup 5\ISCC.exe"
-if not defined INNOSETUP if exist "%ProgramW6432%\Inno Setup 5\ISCC.exe" set INNOSETUP="%ProgramW6432%\Inno Setup 5\ISCC.exe"
-if not defined INNOSETUP if exist "%SystemDrive%\Inno Setup 5\ISCC.exe" set INNOSETUP="%SystemDrive%\Inno Setup 5\ISCC.exe"
+for %%v in (5 6) do (
+    if not defined INNOSETUP if exist "%ProgramFiles%\Inno Setup %%~v\ISCC.exe" set INNOSETUP="%ProgramFiles%\Inno Setup %%~v\ISCC.exe"
+    if not defined INNOSETUP if exist "%ProgramFiles(x86)%\Inno Setup %%~v\ISCC.exe" set INNOSETUP="%ProgramFiles(x86)%\Inno Setup %%~v\ISCC.exe"
+    if not defined INNOSETUP if exist "%ProgramW6432%\Inno Setup %%~v\ISCC.exe" set INNOSETUP="%ProgramW6432%\Inno Setup %%~v\ISCC.exe"
+    if not defined INNOSETUP if exist "%SystemDrive%\Inno Setup %%~v\ISCC.exe" set INNOSETUP="%SystemDrive%\Inno Setup %%~v\ISCC.exe"
+)
 if not defined INNOSETUP echo build.cmd: Can't find InnoSetup! & exit /b 1
 echo build.cmd: Found InnoSetup at: %INNOSETUP%
 

--- a/src/copyfiles.bat
+++ b/src/copyfiles.bat
@@ -14,22 +14,22 @@ if %PLATFORM%==x64   set PLATFORM_X=x64
 
 set DBGHELPERS=dbghelp_%PLATFORM_X%
 copy /y %DBGHELPERS%\*.* %DEST%
-if errorlevel 1 exit /b 1
+if errorlevel 1 ((@ECHO Failed to copy dbghelp_*) & (exit /b 1))
 
-                   if not exist %DBGHELPERS%\dbghelpw.dll       copy /y "thirdparty\wine\dlls\dbghelp\vs\bin\%PLATFORM%\%CONFIGURATION%\dbghelpw.dll"         %DEST%
-if errorlevel 1 exit /b 1
-if %PLATFORM%==x64 if not exist %DBGHELPERS%\dbghelpw_wow64.dll copy /y "thirdparty\wine\dlls\dbghelp\vs\bin\%PLATFORM%\%CONFIGURATION% - Wow64\dbghelpw.dll" %DEST%\dbghelpw_wow64.dll
-if errorlevel 1 exit /b 1
+if not exist "%DBGHELPERS%\dbghelpw.dll" copy /y "thirdparty\wine\dlls\dbghelp\vs\bin\%PLATFORM%\%CONFIGURATION%\dbghelpw.dll" "%DEST%"
+if errorlevel 1 ((@ECHO Failed to copy dbghelpw.dll) & (exit /b 1))
+if %PLATFORM%==x64 if not exist "%DBGHELPERS%\dbghelpw_wow64.dll" copy /y "thirdparty\wine\dlls\dbghelp\vs\bin\%PLATFORM%\%CONFIGURATION% - Wow64\dbghelpw.dll" "%DEST%\dbghelpw_wow64.dll"
+if errorlevel 1 ((@ECHO Failed to copy dbghelpw_wow64.dll) & (exit /b 1))
 
 if %PLATFORM%==Win32 set PLATFORM_BITS=32
 if %PLATFORM%==x64   set PLATFORM_BITS=64
 
-if not exist %DBGHELPERS%\dbghelpdr.dll copy thirdparty\drmingw_build_%PLATFORM_BITS%\bin\mgwhelp.dll %DEST%\dbghelpdr.dll
-if errorlevel 1 exit /b 1
+if not exist "%DBGHELPERS%\dbghelpdr.dll" copy "thirdparty\drmingw_build_%PLATFORM_BITS%\bin\mgwhelp.dll" "%DEST%\dbghelpdr.dll"
+if errorlevel 1 ((@ECHO Failed to copy mgwhelp.dll : dbghelpdr.dll) & (exit /b 1))
 
 if not defined VCINSTALLDIR if defined VS120COMNTOOLS set VCINSTALLDIR=%VS120COMNTOOLS%\..\..\VC
-for %%D in (msvcr120.dll msvcp120.dll) do copy "%VCINSTALLDIR%\redist\%PLATFORM_X%\Microsoft.VC120.CRT\%%D" %DEST%\%%D
+for %%D in (msvcr120.dll msvcp120.dll) do copy "%VCINSTALLDIR%\redist\%PLATFORM_X%\Microsoft.VC120.CRT\%%D" "%DEST%\%%D"
 if errorlevel 1 echo copyfiles.bat: Warning: couldn't copy the C/C++ runtime DLLs
 
-copy /y src\crashback\crashreport\bin\%PLATFORM%\%CONFIGURATION%\crashreport.exe %DEST%
-if errorlevel 1 exit /b 1
+copy /y "src\crashback\crashreport\bin\%PLATFORM%\%CONFIGURATION%\crashreport.exe" "%DEST%"
+if errorlevel 1 ((@ECHO Failed to copy crashreport.exe) & (exit /b 1))

--- a/src/copyfiles.bat
+++ b/src/copyfiles.bat
@@ -14,22 +14,22 @@ if %PLATFORM%==x64   set PLATFORM_X=x64
 
 set DBGHELPERS=dbghelp_%PLATFORM_X%
 copy /y %DBGHELPERS%\*.* %DEST%
-if errorlevel 1 ((@ECHO Failed to copy dbghelp_*) & (exit /b 1))
+if errorlevel 1 ((@echo Failed to copy dbghelp_*) & (exit /b 1))
 
 if not exist "%DBGHELPERS%\dbghelpw.dll" copy /y "thirdparty\wine\dlls\dbghelp\vs\bin\%PLATFORM%\%CONFIGURATION%\dbghelpw.dll" "%DEST%"
-if errorlevel 1 ((@ECHO Failed to copy dbghelpw.dll) & (exit /b 1))
+if errorlevel 1 ((@echo Failed to copy dbghelpw.dll) & (exit /b 1))
 if %PLATFORM%==x64 if not exist "%DBGHELPERS%\dbghelpw_wow64.dll" copy /y "thirdparty\wine\dlls\dbghelp\vs\bin\%PLATFORM%\%CONFIGURATION% - Wow64\dbghelpw.dll" "%DEST%\dbghelpw_wow64.dll"
-if errorlevel 1 ((@ECHO Failed to copy dbghelpw_wow64.dll) & (exit /b 1))
+if errorlevel 1 ((@echo Failed to copy dbghelpw_wow64.dll) & (exit /b 1))
 
 if %PLATFORM%==Win32 set PLATFORM_BITS=32
 if %PLATFORM%==x64   set PLATFORM_BITS=64
 
 if not exist "%DBGHELPERS%\dbghelpdr.dll" copy "thirdparty\drmingw_build_%PLATFORM_BITS%\bin\mgwhelp.dll" "%DEST%\dbghelpdr.dll"
-if errorlevel 1 ((@ECHO Failed to copy mgwhelp.dll : dbghelpdr.dll) & (exit /b 1))
+if errorlevel 1 ((@echo Failed to copy mgwhelp.dll : dbghelpdr.dll) & (exit /b 1))
 
 if not defined VCINSTALLDIR if defined VS120COMNTOOLS set VCINSTALLDIR=%VS120COMNTOOLS%\..\..\VC
 for %%D in (msvcr120.dll msvcp120.dll) do copy "%VCINSTALLDIR%\redist\%PLATFORM_X%\Microsoft.VC120.CRT\%%D" "%DEST%\%%D"
 if errorlevel 1 echo copyfiles.bat: Warning: couldn't copy the C/C++ runtime DLLs
 
 copy /y "src\crashback\crashreport\bin\%PLATFORM%\%CONFIGURATION%\crashreport.exe" "%DEST%"
-if errorlevel 1 ((@ECHO Failed to copy crashreport.exe) & (exit /b 1))
+if errorlevel 1 ((@echo Failed to copy crashreport.exe) & (exit /b 1))

--- a/src/profiler/debugger.cpp
+++ b/src/profiler/debugger.cpp
@@ -52,7 +52,7 @@ void Debugger::notifyNewThread(DWORD threadId, HANDLE threadHandle)
 bool Debugger::attach(std::function<void(NotifyData const &notification)> notifyFunc_)
 {
 	assert(!processHandle);
-	assert(!debuggerThread);
+	//assert(!debuggerThread);
 	assert(!notifyFunc);
 	assert(notifyFunc_);
 	assert(knownThreads.empty());
@@ -66,7 +66,7 @@ bool Debugger::attach(std::function<void(NotifyData const &notification)> notify
 	else
 	{
 		finishAttaching();
-		assert(!debuggerActive);
+		//assert(!debuggerActive);
 	}
 
 	while (!attached)
@@ -106,7 +106,7 @@ void Debugger::update()
 
 void Debugger::deactivateDebugging()
 {
-	assert(debuggerActive);
+	//assert(debuggerActive);
 	debuggingActive = false;
 	DebugActiveProcessStop(processId);
 }

--- a/src/profiler/debugger.cpp
+++ b/src/profiler/debugger.cpp
@@ -52,7 +52,6 @@ void Debugger::notifyNewThread(DWORD threadId, HANDLE threadHandle)
 bool Debugger::attach(std::function<void(NotifyData const &notification)> notifyFunc_)
 {
 	assert(!processHandle);
-	//assert(!debuggerThread);
 	assert(!notifyFunc);
 	assert(notifyFunc_);
 	assert(knownThreads.empty());
@@ -66,7 +65,7 @@ bool Debugger::attach(std::function<void(NotifyData const &notification)> notify
 	else
 	{
 		finishAttaching();
-		//assert(!debuggerActive);
+		assert(!debuggingActive);
 	}
 
 	while (!attached)
@@ -106,7 +105,7 @@ void Debugger::update()
 
 void Debugger::deactivateDebugging()
 {
-	//assert(debuggerActive);
+	assert(debuggingActive);
 	debuggingActive = false;
 	DebugActiveProcessStop(processId);
 }
@@ -204,7 +203,7 @@ void Debugger::updateDebugging()
 				break;
 
 			case CREATE_PROCESS_DEBUG_EVENT:
-				assert(!debugger->processHandle);
+				assert(!processHandle);
 				processHandle = dbgEvent.u.CreateProcessInfo.hProcess;
 				notifyNewThread(dbgEvent.dwThreadId, dbgEvent.u.CreateProcessInfo.hThread);
 				knownThreads.insert(std::make_pair(dbgEvent.dwThreadId, true));

--- a/src/profiler/profiler.cpp
+++ b/src/profiler/profiler.cpp
@@ -112,7 +112,7 @@ void applyHacks(HANDLE process_handle, CONTEXT32 &context)
 
 	// First, skip over any stub functions (a useless push/mov/pop header, followed by a jump).
 	// Move instead to the jump target.
-	if (ReadProcessMemory(process_handle, (LPCVOID)context.Eip, tmp, 16, &numRead) && numRead >= 16)
+	if (ReadProcessMemory(process_handle, reinterpret_cast<LPCVOID>((uintptr_t)context.Eip), tmp, 16, &numRead) && numRead >= 16)
 	{
 		int n = 0;
 
@@ -136,13 +136,13 @@ void applyHacks(HANDLE process_handle, CONTEXT32 &context)
 	}
 
 	// Skip over any jmp [__imp__blah] thunks.
-	if (ReadProcessMemory(process_handle, (LPCVOID)context.Eip, tmp, 16, &numRead) && numRead >= 16)
+	if (ReadProcessMemory(process_handle, reinterpret_cast<LPCVOID>((uintptr_t)context.Eip), tmp, 16, &numRead) && numRead >= 16)
 	{
 		// Look for "jmp [foo]", and move the IP forward to '[foo]'.
 		if (tmp[0] == 0xff && tmp[1] == 0x25)
 		{
 			DWORD ptr = (tmp[5] << 24) | (tmp[4] << 16) | (tmp[3] << 8) | (tmp[2] << 0);
-			if (ReadProcessMemory(process_handle, (LPCVOID)ptr, tmp, 4, &numRead) && numRead >= 4)
+			if (ReadProcessMemory(process_handle, reinterpret_cast<LPCVOID>((uintptr_t)ptr), tmp, 4, &numRead) && numRead >= 4)
 			{
 				context.Eip = (tmp[3] << 24) | (tmp[2] << 16) | (tmp[1] << 8) | (tmp[0] << 0);
 			}
@@ -279,7 +279,7 @@ bool Profiler::sampleTarget(SAMPLE_TYPE timeSpent, SymbolInfo *syminfo)
 			stack.addr[stack.depth++] = ip;
 		first = false;
 
-		BOOL result = dbgHelp->StackWalk64(
+		BOOL result2 = dbgHelp->StackWalk64(
 			machine,
 			target_process,
 			target_thread,
@@ -291,7 +291,7 @@ bool Profiler::sampleTarget(SAMPLE_TYPE timeSpent, SymbolInfo *syminfo)
 			NULL
 		);
 
-		if (!result || stack.depth >= MAX_CALLSTACK_LEVELS)
+		if (!result2 || stack.depth >= MAX_CALLSTACK_LEVELS)
 			break;
 
 		ip = (PROFILER_ADDR)frame.AddrPC.Offset;

--- a/src/profiler/profilerthread.cpp
+++ b/src/profiler/profilerthread.cpp
@@ -126,7 +126,7 @@ void ProfilerThread::sample(const SAMPLE_TYPE timeSpent)
 		}
 	}
 
-	for (ptrdiff_t n = (ptrdiff_t)count; n >= 0; --n)
+	for (ptrdiff_t n = (ptrdiff_t)count-1; n >= 0; --n)
 	{
 		if (!failedProfilers[n] || !profilers[n].targetExited())
 			continue;

--- a/src/wxProfilerGUI/profilergui.cpp
+++ b/src/wxProfilerGUI/profilergui.cpp
@@ -306,7 +306,6 @@ AttachInfo::AttachInfo()
 	process_handle = NULL;
 	attach_all_threads = true;
 	sym_info = NULL;
-	delay_profile = 0; // unused?
 	limit_profile_time = cmdline_timeout;
 }
 

--- a/src/wxProfilerGUI/profilergui.cpp
+++ b/src/wxProfilerGUI/profilergui.cpp
@@ -304,7 +304,9 @@ std::wstring ProfilerGUI::LaunchProfiler(const AttachInfo *info)
 AttachInfo::AttachInfo()
 {
 	process_handle = NULL;
+	attach_all_threads = true;
 	sym_info = NULL;
+	delay_profile = 0; // unused?
 	limit_profile_time = cmdline_timeout;
 }
 

--- a/src/wxProfilerGUI/profilergui.cpp
+++ b/src/wxProfilerGUI/profilergui.cpp
@@ -642,25 +642,15 @@ bool ProfilerGUI::Run()
 	{
 		std::unique_ptr<AttachInfo> info(AttachToProcess(cmdline_attach));
 		if (!cmdline_thread_ids.empty()) {
-			std::cout << "(Orig) Profiling Threads: ";
-			for (auto hwnd : info->thread_handles)
-				std::cout << " " << (uintptr_t)hwnd;
 			std::vector<HANDLE> profile_threads;
 			for (auto tid_h : info->thread_handles) {
 				DWORD test_tid = GetThreadId(tid_h);
-				std::cout << "Checking thread handle: " << (uintptr_t)tid_h << "/" << test_tid << "\n";
-				if (std::find(cmdline_thread_ids.begin(),cmdline_thread_ids.end(),test_tid)
-					!= cmdline_thread_ids.end()) {
-					std::cout << "  Match!\n";
+				if (std::find(cmdline_thread_ids.begin(),cmdline_thread_ids.end(),test_tid) != cmdline_thread_ids.end()) {
 					profile_threads.push_back(tid_h);
 				}
 			}
 			info->thread_handles = profile_threads;
-			std::cout << "Profiling Threads: ";
-			for (auto hwnd : info->thread_handles)
-				std::cout << " " << (uintptr_t)hwnd;
-			std::cout << "\n";
-
+			// Is there a threshold we should use to set this? (currently: attach_count < total_count)
 			info->attach_all_threads = false;
 		}
 		else {

--- a/src/wxProfilerGUI/profilergui.cpp
+++ b/src/wxProfilerGUI/profilergui.cpp
@@ -728,7 +728,6 @@ bool ProfilerGUI::OnCmdLineParsed(wxCmdLineParser& parser)
 	if (parser.Found("a", &param))
 		cmdline_attach = param.c_str();
 	if (parser.Found("thread", &param)) {
-		std::cout << "-thread found (" << param << ")\n";
 		auto tids_str = wxSplit(param,',');
 		for (size_t i=0; i<tids_str.GetCount(); i++) {
 			long tid;
@@ -736,10 +735,6 @@ bool ProfilerGUI::OnCmdLineParsed(wxCmdLineParser& parser)
 				cmdline_thread_ids.push_back(tid);
 			}
 		}
-		std::cout << "  Threads to attach to (";
-		for (auto& tid : cmdline_thread_ids)
-			std::cout << " " << tid;
-		std::cout << " )\n";
 	}
 	if (parser.Found("wine"))
 		prefs.useWineSwitch = true;

--- a/src/wxProfilerGUI/profilergui.cpp
+++ b/src/wxProfilerGUI/profilergui.cpp
@@ -62,6 +62,7 @@ static const wxCmdLineEntryDesc g_cmdLineDesc[] =
 	{ wxCMD_LINE_SWITCH, "h", "", "Displays help on the command line parameters.",			wxCMD_LINE_VAL_NONE, wxCMD_LINE_OPTION_HELP },
 	{ wxCMD_LINE_OPTION, "r", "", "Runs an executable and profiles it.",					wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL|wxCMD_LINE_NEEDS_SEPARATOR },
 	{ wxCMD_LINE_OPTION, "a", "", "Attaches to a process (by its PID) and profiles it.",	wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL|wxCMD_LINE_NEEDS_SEPARATOR },
+	{ wxCMD_LINE_OPTION, "thread", "", "Profiles the specified thread(s) in the process, multiple threads must be in a comma-delimited list (See -a for specifying the process ID).",	wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL|wxCMD_LINE_NEEDS_SEPARATOR },
 	{ wxCMD_LINE_OPTION, "i", "", "Loads an existing profile from a file.",					wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL|wxCMD_LINE_NEEDS_SEPARATOR },
 	{ wxCMD_LINE_OPTION, "o", "", "Saves the captured profile to the given file.",			wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL|wxCMD_LINE_NEEDS_SEPARATOR },
 	{ wxCMD_LINE_OPTION, "d", "", "Waits N seconds before beginning capture.",				wxCMD_LINE_VAL_NUMBER, wxCMD_LINE_PARAM_OPTIONAL },
@@ -80,6 +81,7 @@ wxIcon sleepy_icon;
 std::wstring cmdline_load, cmdline_save, cmdline_run, cmdline_attach;
 long cmdline_delay = 0;
 long cmdline_timeout = -1;  // -1 means profile until cancelled
+std::vector<DWORD> cmdline_thread_ids;
 std::vector<std::wstring> tmp_files;
 Prefs prefs;
 wxConfig config(_T(APPNAME), _T(VENDOR));
@@ -637,6 +639,26 @@ bool ProfilerGUI::Run()
 	else if (!cmdline_attach.empty())
 	{
 		std::unique_ptr<AttachInfo> info(AttachToProcess(cmdline_attach));
+		if (!cmdline_thread_ids.empty()) {
+			std::cout << "(Orig) Profiling Threads: ";
+			for (auto hwnd : info->thread_handles)
+				std::cout << " " << (uintptr_t)hwnd;
+			std::vector<HANDLE> profile_threads;
+			for (auto tid_h : info->thread_handles) {
+				DWORD test_tid = GetThreadId(tid_h);
+				std::cout << "Checking thread handle: " << (uintptr_t)tid_h << "/" << test_tid << "\n";
+				if (std::find(cmdline_thread_ids.begin(),cmdline_thread_ids.end(),test_tid)
+					!= cmdline_thread_ids.end()) {
+					std::cout << "  Match!\n";
+					profile_threads.push_back(tid_h);
+				}
+			}
+			info->thread_handles = profile_threads;
+			std::cout << "Profiling Threads: ";
+			for (auto hwnd : info->thread_handles)
+				std::cout << " " << (uintptr_t)hwnd;
+			std::cout << "\n";
+		}
 		filename = LaunchProfiler(info.get());
 	}
 	else if (!cmdline_load.empty())
@@ -705,6 +727,20 @@ bool ProfilerGUI::OnCmdLineParsed(wxCmdLineParser& parser)
 		cmdline_run = param.c_str();
 	if (parser.Found("a", &param))
 		cmdline_attach = param.c_str();
+	if (parser.Found("thread", &param)) {
+		std::cout << "-thread found (" << param << ")\n";
+		auto tids_str = wxSplit(param,',');
+		for (size_t i=0; i<tids_str.GetCount(); i++) {
+			long tid;
+			if (tids_str[i].ToLong(&tid)) {
+				cmdline_thread_ids.push_back(tid);
+			}
+		}
+		std::cout << "  Threads to attach to (";
+		for (auto& tid : cmdline_thread_ids)
+			std::cout << " " << tid;
+		std::cout << " )\n";
+	}
 	if (parser.Found("wine"))
 		prefs.useWineSwitch = true;
 	if (parser.Found("mingw"))

--- a/src/wxProfilerGUI/profilergui.cpp
+++ b/src/wxProfilerGUI/profilergui.cpp
@@ -658,6 +658,11 @@ bool ProfilerGUI::Run()
 			for (auto hwnd : info->thread_handles)
 				std::cout << " " << (uintptr_t)hwnd;
 			std::cout << "\n";
+
+			info->attach_all_threads = false;
+		}
+		else {
+			info->attach_all_threads = true;
 		}
 		filename = LaunchProfiler(info.get());
 	}

--- a/src/wxProfilerGUI/profilergui.cpp
+++ b/src/wxProfilerGUI/profilergui.cpp
@@ -649,7 +649,6 @@ bool ProfilerGUI::Run()
 				}
 			}
 			info->thread_handles = profile_threads;
-			// Is there a threshold we should use to set this? (currently: attach_count < total_count)
 			info->attach_all_threads = false;
 		}
 		else {

--- a/src/wxProfilerGUI/profilergui.cpp
+++ b/src/wxProfilerGUI/profilergui.cpp
@@ -62,7 +62,7 @@ static const wxCmdLineEntryDesc g_cmdLineDesc[] =
 	{ wxCMD_LINE_SWITCH, "h", "", "Displays help on the command line parameters.",			wxCMD_LINE_VAL_NONE, wxCMD_LINE_OPTION_HELP },
 	{ wxCMD_LINE_OPTION, "r", "", "Runs an executable and profiles it.",					wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL|wxCMD_LINE_NEEDS_SEPARATOR },
 	{ wxCMD_LINE_OPTION, "a", "", "Attaches to a process (by its PID) and profiles it.",	wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL|wxCMD_LINE_NEEDS_SEPARATOR },
-	{ wxCMD_LINE_OPTION, "thread", "", "Profiles the specified thread(s) in the process, multiple threads must be in a comma-delimited list (See -a for specifying the process ID).",	wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL|wxCMD_LINE_NEEDS_SEPARATOR },
+	{ wxCMD_LINE_OPTION, "thread", "", "Profiles the specified thread(s) in the process, multiple threads must be in a comma-delimited list without spaces (See /a for specifying the process ID). Examples: `/thread:2124` or `/thread:8086,24601,42`",	wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL|wxCMD_LINE_NEEDS_SEPARATOR },
 	{ wxCMD_LINE_OPTION, "i", "", "Loads an existing profile from a file.",					wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL|wxCMD_LINE_NEEDS_SEPARATOR },
 	{ wxCMD_LINE_OPTION, "o", "", "Saves the captured profile to the given file.",			wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL|wxCMD_LINE_NEEDS_SEPARATOR },
 	{ wxCMD_LINE_OPTION, "d", "", "Waits N seconds before beginning capture.",				wxCMD_LINE_VAL_NUMBER, wxCMD_LINE_PARAM_OPTIONAL },

--- a/src/wxProfilerGUI/profilergui.h
+++ b/src/wxProfilerGUI/profilergui.h
@@ -61,7 +61,6 @@ struct AttachInfo
 	std::vector<HANDLE> thread_handles;
 	bool attach_all_threads;
 	SymbolInfo *sym_info;
-	int delay_profile;
 	int limit_profile_time;
 };
 

--- a/src/wxProfilerGUI/threadpicker.cpp
+++ b/src/wxProfilerGUI/threadpicker.cpp
@@ -355,6 +355,7 @@ void ThreadPicker::AttachToProcess(bool allThreads)
 	assert(IsModal());
 
 	attach_info = new AttachInfo;
+	attach_info->attach_all_threads = allThreads;
 
 	const ProcessInfo* processInfo = processlist->getSelectedProcess();
 	enforce(processInfo, "No process selected");

--- a/thirdparty/drmingw_build_mingw.cmd
+++ b/thirdparty/drmingw_build_mingw.cmd
@@ -21,6 +21,7 @@ set MINGW64_FN=x86_64-6.3.0-release-win32-seh-rt_v5-rev1.7z
 set MINGW32_URL=https://sourceforge.net/projects/mingw-w64/files/Toolchains%%20targetting%%20Win32/Personal%%20Builds/mingw-builds/6.3.0/threads-win32/dwarf/%MINGW32_FN%/download
 set MINGW64_URL=https://sourceforge.net/projects/mingw-w64/files/Toolchains%%20targetting%%20Win64/Personal%%20Builds/mingw-builds/6.3.0/threads-win32/seh/%MINGW64_FN%/download
 
+REM  I downloaded these manually.
 for %%t in (32 64) do (
 	set FN=!MINGW%%t_FN!
 	set URL=!MINGW%%t_URL!
@@ -28,6 +29,7 @@ for %%t in (32 64) do (
 	if not exist "%~dp0\mingw\!FN!" (
 		echo Downloading !FN!...
 		set DEST=%~dp0/mingw/!FN!
+                REM If the automagic download fails, download the files manually and put them in this directory.
 		call :download
 		if errorlevel 1 exit /b 1
 	)
@@ -80,6 +82,9 @@ goto :eof
 
 rem Download !URL! to !DEST!.
 rem Note: Positional parameters don't work here, as the percent signs in URLs are eagerly interpreted despite quoting.
+
+@echo Downloading %URL%
+@echo   %DEST%
 
 for %%a in (powershell.exe) do if not [%%~$PATH:a] == [] powershell -Command "(New-Object Net.WebClient).DownloadFile('!URL!', '!DEST!')" & goto :eof
 for %%a in (curl.exe) do if not [%%~$PATH:a] == [] curl "!URL!" -O "!DEST!" --location & goto :eof

--- a/thirdparty/drmingw_build_mingw.cmd
+++ b/thirdparty/drmingw_build_mingw.cmd
@@ -82,8 +82,8 @@ goto :eof
 rem Download !URL! to !DEST!.
 rem Note: Positional parameters don't work here, as the percent signs in URLs are eagerly interpreted despite quoting.
 
-@echo Downloading %URL%
-@echo   %DEST%
+@echo Downloading !URL!
+@echo   !DEST!
 
 for %%a in (powershell.exe) do if not [%%~$PATH:a] == [] powershell -Command "(New-Object Net.WebClient).DownloadFile('!URL!', '!DEST!')" & goto :eof
 for %%a in (curl.exe) do if not [%%~$PATH:a] == [] curl "!URL!" -O "!DEST!" --location & goto :eof

--- a/thirdparty/drmingw_build_mingw.cmd
+++ b/thirdparty/drmingw_build_mingw.cmd
@@ -21,7 +21,6 @@ set MINGW64_FN=x86_64-6.3.0-release-win32-seh-rt_v5-rev1.7z
 set MINGW32_URL=https://sourceforge.net/projects/mingw-w64/files/Toolchains%%20targetting%%20Win32/Personal%%20Builds/mingw-builds/6.3.0/threads-win32/dwarf/%MINGW32_FN%/download
 set MINGW64_URL=https://sourceforge.net/projects/mingw-w64/files/Toolchains%%20targetting%%20Win64/Personal%%20Builds/mingw-builds/6.3.0/threads-win32/seh/%MINGW64_FN%/download
 
-REM  I downloaded these manually.
 for %%t in (32 64) do (
 	set FN=!MINGW%%t_FN!
 	set URL=!MINGW%%t_URL!


### PR DESCRIPTION
## Bug Fixes

  * array out of bounds in `ProfilerThread::sample(...)`
  * ignored input parameter `ThreadPicker::AttachToProcess(...)`
  * cleaned up `assert(...)` to be able to build with Debug configuration(s)

One or more of these was resulting in bad behavior. If you select a single thread and start sampling, the app will sample a single thread once (or a few times), then begin sampling _all_ threads.

## Attach to specific thread(s)

    /thread:<tid>

    /thread:<tid1>,<tid2>,...

In addition to /mt /mbt, this option permits you to sample specific threads, by thread ID.

## Build Scripts

  * added some feedback for failures
  * added support for default install paths for Inno 6
  * defensively quote paths