### PR TITLE
Bug/Compile Fixes

### DIFF
--- a/src/profiler/debugger.cpp
+++ b/src/profiler/debugger.cpp
@@ -52,7 +52,6 @@ void Debugger::notifyNewThread(DWORD threadId, HANDLE threadHandle)
 bool Debugger::attach(std::function<void(NotifyData const &notification)> notifyFunc_)
 {
 	assert(!processHandle);
-	assert(!debuggerThread);
 	assert(!notifyFunc);
 	assert(notifyFunc_);
 	assert(knownThreads.empty());
@@ -66,7 +65,7 @@ bool Debugger::attach(std::function<void(NotifyData const &notification)> notify
 	else
 	{
 		finishAttaching();
-		assert(!debuggerActive);
+		assert(!debuggingActive);
 	}
 
 	while (!attached)
@@ -106,7 +105,7 @@ void Debugger::update()
 
 void Debugger::deactivateDebugging()
 {
-	assert(debuggerActive);
+	assert(debuggingActive);
 	debuggingActive = false;
 	DebugActiveProcessStop(processId);
 }
@@ -204,7 +203,7 @@ void Debugger::updateDebugging()
 				break;
 
 			case CREATE_PROCESS_DEBUG_EVENT:
-				assert(!debugger->processHandle);
+				assert(!processHandle);
 				processHandle = dbgEvent.u.CreateProcessInfo.hProcess;
 				notifyNewThread(dbgEvent.dwThreadId, dbgEvent.u.CreateProcessInfo.hThread);
 				knownThreads.insert(std::make_pair(dbgEvent.dwThreadId, true));

--- a/src/profiler/profilerthread.cpp
+++ b/src/profiler/profilerthread.cpp
@@ -126,7 +126,7 @@ void ProfilerThread::sample(const SAMPLE_TYPE timeSpent)
 		}
 	}
 
-	for (ptrdiff_t n = (ptrdiff_t)count; n >= 0; --n)
+	for (ptrdiff_t n = (ptrdiff_t)count-1; n >= 0; --n)
 	{
 		if (!failedProfilers[n] || !profilers[n].targetExited())
 			continue;

--- a/src/wxProfilerGUI/profilergui.cpp
+++ b/src/wxProfilerGUI/profilergui.cpp
@@ -302,6 +302,7 @@ std::wstring ProfilerGUI::LaunchProfiler(const AttachInfo *info)
 AttachInfo::AttachInfo()
 {
 	process_handle = NULL;
+	attach_all_threads = true;
 	sym_info = NULL;
 	limit_profile_time = cmdline_timeout;
 }

--- a/src/wxProfilerGUI/profilergui.h
+++ b/src/wxProfilerGUI/profilergui.h
@@ -61,7 +61,6 @@ struct AttachInfo
 	std::vector<HANDLE> thread_handles;
 	bool attach_all_threads;
 	SymbolInfo *sym_info;
-	int delay_profile;
 	int limit_profile_time;
 };
 

--- a/src/wxProfilerGUI/threadpicker.cpp
+++ b/src/wxProfilerGUI/threadpicker.cpp
@@ -355,6 +355,7 @@ void ThreadPicker::AttachToProcess(bool allThreads)
 	assert(IsModal());
 
 	attach_info = new AttachInfo;
+	attach_info->attach_all_threads = allThreads;
 
 	const ProcessInfo* processInfo = processlist->getSelectedProcess();
 	enforce(processInfo, "No process selected");


### PR DESCRIPTION
  * (array index out of bounds) fixed invalid initial value of index into `profilers` container
  * `allThreads` input parameter ignored, member variable not initialized
  * fixed or cleaned up `assert(...)` calls for Debug build
  * removed unused class member, `delay_profile`