### PR TITLE
Allow specifying more options from the command line

### DIFF
--- a/src/profiler/profilerthread.cpp
+++ b/src/profiler/profilerthread.cpp
@@ -175,7 +175,7 @@ void ProfilerThread::sampleLoop()
 		double t = (double)diff / (double)freq.QuadPart;
 
 		__int64 elapsed = now.QuadPart - start.QuadPart;
-		if (!minidump_saved && prefs.saveMinidump>=0 && elapsed >= prefs.saveMinidump * freq.QuadPart)
+		if (!minidump_saved && prefs.saveMinidump.GetValue()>=0 && elapsed >= prefs.saveMinidump.GetValue() * freq.QuadPart)
 		{
 			minidump_saved = true;
 			status = L"Saving minidump";
@@ -186,7 +186,7 @@ void ProfilerThread::sampleLoop()
 
 		sample(t);
 
-		int ms = 100 / prefs.throttle;
+		int ms = 100 / prefs.throttle.GetValue();
 		Sleep(ms);
 
 		prev = now;

--- a/src/wxProfilerGUI/database.cpp
+++ b/src/wxProfilerGUI/database.cpp
@@ -168,9 +168,11 @@ void Database::loadFromPath(const std::wstring& _profilepath, bool collapseOSCal
 		loadStats(zip);
 	}
 	{
-		if (zip.OpenEntry(*entries["minidump.dmp"])) {
-			has_minidump = true;
-			if (loadMinidump) this->loadMinidump(zip);
+		if (entries.find("minidump.dmp") != entries.end()) {
+			if (zip.OpenEntry(*entries["minidump.dmp"])) {
+				has_minidump = true;
+				if (loadMinidump) this->loadMinidump(zip);
+			}
 		}
 	}
 	zip.CloseEntry();

--- a/src/wxProfilerGUI/optionsdlg.cpp
+++ b/src/wxProfilerGUI/optionsdlg.cpp
@@ -219,7 +219,7 @@ void OptionsDlg::OnOk(wxCommandEvent& WXUNUSED(event))
 		prefs.symServer = symServer->GetValue();
 		prefs.useWinePref = mingwWine->GetValue();
 		prefs.saveMinidump = saveMinidump->GetValue() ? saveMinidumpTimeValue : -1;
-		prefs.throttle = throttle->GetValue();
+		prefs.throttle = prefs.ValidateThrottle(throttle->GetValue());
 		EndModal(wxID_OK);
 	}
 }

--- a/src/wxProfilerGUI/profilergui.cpp
+++ b/src/wxProfilerGUI/profilergui.cpp
@@ -564,13 +564,13 @@ bool ProfilerGUI::OnInit()
 		// Make a default cache in their user directory.
 		wxString symCache = wxStandardPaths::Get().GetUserLocalDataDir();
 
-		prefs.symSearchPath = config.Read("SymbolSearchPath", "");
-		prefs.useSymServer = config.Read("UseSymbolServer", 1) != 0;
-		prefs.symServer = config.Read("SymbolServer", "http://msdl.microsoft.com/download/symbols");
-		prefs.symCacheDir = config.Read("SymbolCache", symCache);
+		prefs.symSearchPath.SetConfigValue(config.Read("SymbolSearchPath", ""));
+		prefs.useSymServer.SetConfigValue(config.Read("UseSymbolServer", 1) != 0);
+		prefs.symServer.SetConfigValue(config.Read("SymbolServer", "http://msdl.microsoft.com/download/symbols"));
+		prefs.symCacheDir.SetConfigValue(config.Read("SymbolCache", symCache));
 		prefs.useWinePref = config.Read("UseWine", (long)0) != 0;
-		prefs.saveMinidump = config.Read("SaveMinidump", -1);
-		prefs.throttle = prefs.ValidateThrottle(config.Read("SpeedThrottle", 100));
+		prefs.saveMinidump.SetConfigValue(config.Read("SaveMinidump", -1));
+		prefs.throttle.SetConfigValue(prefs.ValidateThrottle(config.Read("SpeedThrottle", 100)));
 
 		if (!wxApp::OnInit())
 			return false;

--- a/src/wxProfilerGUI/profilergui.cpp
+++ b/src/wxProfilerGUI/profilergui.cpp
@@ -60,29 +60,29 @@ http://www.gnu.org/copyleft/gpl.html.
 
 static const wxCmdLineEntryDesc g_cmdLineDesc[] =
 {
-	{ wxCMD_LINE_SWITCH, "h", "", "Displays help on the command line parameters.",			wxCMD_LINE_VAL_NONE, wxCMD_LINE_OPTION_HELP },
-	{ wxCMD_LINE_OPTION, "r", "", "Runs an executable and profiles it.",					wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL|wxCMD_LINE_NEEDS_SEPARATOR },
-	{ wxCMD_LINE_OPTION, "a", "", "Attaches to a process (by its PID) and profiles it.",	wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL|wxCMD_LINE_NEEDS_SEPARATOR },
-	{ wxCMD_LINE_OPTION, "i", "", "Loads an existing profile from a file.",					wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL|wxCMD_LINE_NEEDS_SEPARATOR },
-	{ wxCMD_LINE_OPTION, "o", "", "Saves the captured profile to the given file.",			wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL|wxCMD_LINE_NEEDS_SEPARATOR },
-	{ wxCMD_LINE_OPTION, "d", "", "Waits N seconds before beginning capture.",				wxCMD_LINE_VAL_NUMBER, wxCMD_LINE_PARAM_OPTIONAL },
-	{ wxCMD_LINE_OPTION, "t", "", "Stops capturing automatically after N seconds time.",	wxCMD_LINE_VAL_NUMBER, wxCMD_LINE_PARAM_OPTIONAL },
-	{ wxCMD_LINE_SWITCH, "q", "", "Quiet mode (no error messages will be shown).",			wxCMD_LINE_VAL_NONE },
-	{ wxCMD_LINE_SWITCH, "", "wine", "Use Wine DbgHelp.",									wxCMD_LINE_VAL_NONE },
-	{ wxCMD_LINE_SWITCH, "", "mingw", "Use Dr. MinGW DbgHelp.",								wxCMD_LINE_VAL_NONE },
-	{ wxCMD_LINE_SWITCH, "mt", "", "When attaching a process, profiles only main thread.",	wxCMD_LINE_VAL_NONE },
-	{ wxCMD_LINE_SWITCH, "mbt", "", "When attaching a process, profiles only most busy thread.",	wxCMD_LINE_VAL_NONE },
-	{ wxCMD_LINE_OPTION, "thread", "", "Profiles the specified thread(s) in the process, multiple threads must be in a comma-delimited list without spaces (See /a for specifying the process ID). Examples: `/thread:2124` or `/thread:8086,24601,42`",	wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL|wxCMD_LINE_NEEDS_SEPARATOR },
-
-	{ wxCMD_LINE_OPTION, "minidump", "", "capture a minidump after N seconds time.",	    wxCMD_LINE_VAL_NUMBER, wxCMD_LINE_PARAM_OPTIONAL },
-	{ wxCMD_LINE_OPTION, "samplerate", "", "set the sample rate speed",	    				wxCMD_LINE_VAL_NUMBER, wxCMD_LINE_PARAM_OPTIONAL },
-	{ wxCMD_LINE_OPTION, "symsearchpath", "", "Specify the symbol search path.",			wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL|wxCMD_LINE_NEEDS_SEPARATOR },
+	{ wxCMD_LINE_SWITCH, "h", "", "Displays help on the command line parameters.",          wxCMD_LINE_VAL_NONE, wxCMD_LINE_OPTION_HELP },
+	{ wxCMD_LINE_OPTION, "r", "", "Runs an executable and profiles it.",                    wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL|wxCMD_LINE_NEEDS_SEPARATOR },
+	{ wxCMD_LINE_OPTION, "a", "", "Attaches to a process (by its PID) and profiles it.",    wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL|wxCMD_LINE_NEEDS_SEPARATOR },
+	{ wxCMD_LINE_OPTION, "i", "", "Loads an existing profile from a file.",                 wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL|wxCMD_LINE_NEEDS_SEPARATOR },
+	{ wxCMD_LINE_OPTION, "o", "", "Saves the captured profile to the given file.",          wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL|wxCMD_LINE_NEEDS_SEPARATOR },
+	{ wxCMD_LINE_OPTION, "d", "", "Waits N seconds before beginning capture.",              wxCMD_LINE_VAL_NUMBER, wxCMD_LINE_PARAM_OPTIONAL },
+	{ wxCMD_LINE_OPTION, "t", "", "Stops capturing automatically after N seconds time.",    wxCMD_LINE_VAL_NUMBER, wxCMD_LINE_PARAM_OPTIONAL },
+	{ wxCMD_LINE_SWITCH, "q", "", "Quiet mode (no error messages will be shown).",          wxCMD_LINE_VAL_NONE },
+	{ wxCMD_LINE_SWITCH, "", "wine", "Use Wine DbgHelp.",                                   wxCMD_LINE_VAL_NONE },
+	{ wxCMD_LINE_SWITCH, "", "mingw", "Use Dr. MinGW DbgHelp.",                             wxCMD_LINE_VAL_NONE },
+	{ wxCMD_LINE_SWITCH, "mt", "", "When attaching a process, profiles only main thread.",  wxCMD_LINE_VAL_NONE },
+	{ wxCMD_LINE_SWITCH, "mbt", "", "When attaching a process, profiles only most busy thread.",    wxCMD_LINE_VAL_NONE },
+	{ wxCMD_LINE_OPTION, "thread", "", "Profiles the specified thread(s) in the process, multiple threads must be in a comma-delimited list without spaces (See /a for specifying the process ID). Examples: `/thread:2124` or `/thread:8086,24601,42`",    wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL|wxCMD_LINE_NEEDS_SEPARATOR },
+	
+	{ wxCMD_LINE_OPTION, "minidump", "", "capture a minidump after N seconds time.",        wxCMD_LINE_VAL_NUMBER, wxCMD_LINE_PARAM_OPTIONAL },
+	{ wxCMD_LINE_OPTION, "samplerate", "", "set the sample rate speed",                     wxCMD_LINE_VAL_NUMBER, wxCMD_LINE_PARAM_OPTIONAL },
+	{ wxCMD_LINE_OPTION, "symsearchpath", "", "Specify the symbol search path.",            wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL|wxCMD_LINE_NEEDS_SEPARATOR },
 	{ wxCMD_LINE_OPTION, "symcachedir", "", "Specify the directory to use for the symbol cache.", wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL|wxCMD_LINE_NEEDS_SEPARATOR },
-	{ wxCMD_LINE_SWITCH, "usesymserver", "", "Use a symbol server.",						wxCMD_LINE_VAL_NONE, wxCMD_LINE_SWITCH_NEGATABLE },
-	{ wxCMD_LINE_OPTION, "symserver", "", "Specify the symbol server path/URL.",			wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL|wxCMD_LINE_NEEDS_SEPARATOR },
-
-	{ wxCMD_LINE_PARAM, NULL, NULL, "Loads an existing profile from a file.",				wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL},
-
+	{ wxCMD_LINE_SWITCH, "usesymserver", "", "Use a symbol server.",                        wxCMD_LINE_VAL_NONE, wxCMD_LINE_SWITCH_NEGATABLE },
+	{ wxCMD_LINE_OPTION, "symserver", "", "Specify the symbol server path/URL.",            wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL|wxCMD_LINE_NEEDS_SEPARATOR },
+	
+	{ wxCMD_LINE_PARAM, NULL, NULL, "Loads an existing profile from a file.",               wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL},
+	
 	{ wxCMD_LINE_NONE }
 };
 
@@ -561,9 +561,6 @@ bool ProfilerGUI::OnInit()
 
 		sleepy_icon = wxICON(sleepy);
 
-		if (!wxApp::OnInit())
-			return false;
-
 		// Make a default cache in their user directory.
 		wxString symCache = wxStandardPaths::Get().GetUserLocalDataDir();
 
@@ -573,8 +570,10 @@ bool ProfilerGUI::OnInit()
 		prefs.symCacheDir = config.Read("SymbolCache", symCache);
 		prefs.useWinePref = config.Read("UseWine", (long)0) != 0;
 		prefs.saveMinidump = config.Read("SaveMinidump", -1);
-		prefs.throttle = config.Read("SpeedThrottle", 100);
-		prefs.ValidateThrottle();
+		prefs.throttle = prefs.ValidateThrottle(config.Read("SpeedThrottle", 100));
+
+		if (!wxApp::OnInit())
+			return false;
 
 		return true;
 	}
@@ -681,19 +680,13 @@ bool ProfilerGUI::Run()
 
 int ProfilerGUI::OnExit()
 {
-	if (! prefs.symSearchPath_nosave)
-		config.Write("SymbolSearchPath", prefs.symSearchPath);
-	if (! prefs.useSymServer_nosave)
-		config.Write("UseSymbolServer", prefs.useSymServer);
-	if (! prefs.symServer_nosave)
-		config.Write("SymbolServer", prefs.symServer);
-	if (! prefs.symCacheDir_nosave)
-		config.Write("SymbolCache", prefs.symCacheDir);
+	config.Write("SymbolSearchPath", prefs.symSearchPath.GetConfigValue());
+	config.Write("UseSymbolServer", prefs.useSymServer.GetConfigValue());
+	config.Write("SymbolServer", prefs.symServer.GetConfigValue());
+	config.Write("SymbolCache", prefs.symCacheDir.GetConfigValue());
 	config.Write("UseWine", prefs.useWinePref);
-	if (! prefs.saveMinidump_nosave)
-		config.Write("SaveMinidump", prefs.saveMinidump);
-	if (! prefs.throttle_nosave)
-		config.Write("SpeedThrottle", prefs.throttle);
+	config.Write("SaveMinidump", prefs.saveMinidump.GetConfigValue());
+	config.Write("SpeedThrottle", prefs.throttle.GetConfigValue());
 
 	return wxApp::OnExit();
 }
@@ -710,7 +703,7 @@ bool ProfilerGUI::OnCmdLineParsed(wxCmdLineParser& parser)
 	wxString param;
 	long long_param;
 
-	// Command line options that override saved setting, will not replace
+	// command line options that override saved setting, will not replace
 	//   the data in the saved config.
 
 	if (parser.Found("q"))
@@ -736,28 +729,28 @@ bool ProfilerGUI::OnCmdLineParsed(wxCmdLineParser& parser)
 		cmdline_run = param.c_str();
 	if (parser.Found("a", &param))
 		cmdline_attach = param.c_str();
-	if (parser.Found("thread", &param)) {
+	if (parser.Found("thread", &param))
+	{
 		auto tids_str = wxSplit(param,',');
-		for (size_t i=0; i<tids_str.GetCount(); i++) {
+		for (size_t i=0; i<tids_str.GetCount(); i++)
+		{
 			long tid;
-			if (tids_str[i].ToLong(&tid)) {
+			if (tids_str[i].ToLong(&tid))
+			{
 				cmdline_thread_ids.push_back(tid);
-			} else {
+			}
+			else
+			{
 				wxMessageBox(wxString::Format(wxT("Ignoring malformed thread ID in /thread option: %s"), tids_str[i]),
 							 APPNAME,
 							 wxICON_WARNING);
 			}
 		}
 	}
-	if (parser.Found("minidump",&long_param)) {
-		prefs.saveMinidump = long_param;
-		prefs.saveMinidump_nosave = true;
-	}
-	if (parser.Found("samplerate",&long_param)) {
-		prefs.throttle = long_param;
-		prefs.ValidateThrottle();
-		prefs.throttle_nosave = true;
-	}
+	if (parser.Found("minidump",&long_param))
+		prefs.saveMinidump.Override(long_param);
+	if (parser.Found("samplerate",&long_param))
+		prefs.throttle.Override(prefs.ValidateThrottle(long_param));
 	if (parser.Found("wine"))
 		prefs.useWineSwitch = true;
 	if (parser.Found("mingw"))
@@ -766,23 +759,14 @@ bool ProfilerGUI::OnCmdLineParsed(wxCmdLineParser& parser)
 		prefs.attachMode = ATTACH_MAIN_THREAD;
 	if (parser.Found("mbt", &param))
 		prefs.attachMode = ATTACH_MOST_BUSY_THREAD;
-
-	if (parser.Found("symsearchpath", &param)) {
-		prefs.symSearchPath = param;
-		prefs.symSearchPath_nosave = true;
-	}
-	if (parser.Found("symcachedir", &param)) {
-		prefs.symCacheDir = param;
-		prefs.symCacheDir_nosave = true;
-	}
-	if (auto state = parser.FoundSwitch("usesymserver")) {
-		prefs.useSymServer = state == wxCMD_SWITCH_ON;
-		prefs.useSymServer_nosave = true;
-	}
-	if (parser.Found("symserver", &param)) {
-		prefs.symServer = param;
-		prefs.symServer_nosave = true;
-	}
+	if (parser.Found("symsearchpath", &param))
+		prefs.symSearchPath.Override(param);
+	if (parser.Found("symcachedir", &param))
+		prefs.symCacheDir.Override(param);
+	if (auto state = parser.FoundSwitch("usesymserver"))
+		prefs.useSymServer.Override(state == wxCMD_SWITCH_ON);
+	if (parser.Found("symserver", &param))
+		prefs.symServer.Override(param);
 
 	return true;
 }

--- a/src/wxProfilerGUI/profilergui.h
+++ b/src/wxProfilerGUI/profilergui.h
@@ -116,15 +116,6 @@ public:
 	{
 		return config_value;
 	}
-	T GetOverrideValue() const
-	{
-		return override_value;
-	}
-
-	bool IsOverridden() const
-	{
-		return is_overridden;
-	}
 
 protected:
 	T config_value;

--- a/src/wxProfilerGUI/profilergui.h
+++ b/src/wxProfilerGUI/profilergui.h
@@ -76,6 +76,14 @@ public:
 		throttle = 100;
 		useWinePref = useWineSwitch = useMingwSwitch = false;
 		attachMode = ATTACH_ALL_THREAD;
+
+		// The default behavior is to save them.
+		saveMinidump_nosave = 
+			throttle_nosave = 
+			symSearchPath_nosave = 
+			useSymServer_nosave =
+			symCacheDir_nosave =
+			symServer_nosave = false;
 	}
 
 	wxString symSearchPath;
@@ -84,6 +92,16 @@ public:
 	wxString symServer;
 	int saveMinidump; // Save minidump after X seconds. -1 = disabled
 	int throttle;
+
+	// Because the above settings are saved to persistent storage, provide a
+	// 	 means to specify them for a particular run (e.g. command line) without
+	// 	 saving them.
+	bool symSearchPath_nosave;
+	bool useSymServer_nosave;
+	bool symCacheDir_nosave;
+	bool symServer_nosave;
+	bool saveMinidump_nosave;
+	bool throttle_nosave; 
 
 	bool useWinePref, useWineSwitch, useMingwSwitch;
 	AttachMode attachMode;
@@ -115,6 +133,13 @@ public:
 			if ( download )
 				sympath += std::wstring(L"*") + symServer;
 		}
+	}
+
+	void ValidateThrottle() {
+		if (throttle < 1)
+			throttle = 1;
+		if (throttle > 100)
+			throttle = 100;
 	}
 };
 

--- a/src/wxProfilerGUI/profilergui.h
+++ b/src/wxProfilerGUI/profilergui.h
@@ -93,19 +93,19 @@ public:
 		override_value = ovr_value;
 	}
 
-	// Using this replaces an override value.
-	T& operator =( const T& new_value )
-	{
-		is_overridden = false;
-		config_value = new_value;
-		return config_value;
-	}
+	// // Using this replaces an override value.
+	// T& operator =( const T& new_value )
+	// {
+	// 	is_overridden = false;
+	// 	config_value = new_value;
+	// 	return config_value;
+	// }
 
 	// getters
-	operator T() const
-	{
-		return GetValue();
-	}
+	// operator T() const
+	// {
+	// 	return GetValue();
+	// }
 
 	T GetValue() const
 	{
@@ -115,6 +115,10 @@ public:
 	T GetConfigValue() const
 	{
 		return config_value;
+	}
+
+	bool IsOverridden() const {
+		return is_overridden;
 	}
 
 protected:
@@ -161,7 +165,7 @@ public:
 			sympath += symSearchPath.GetValue();
 		}
 
-		if (useSymServer)
+		if (useSymServer.GetValue())
 		{
 			if (!sympath.empty())
 				sympath += L";";

--- a/src/wxProfilerGUI/profilergui.h
+++ b/src/wxProfilerGUI/profilergui.h
@@ -66,42 +66,88 @@ struct AttachInfo
 
 wxBitmap LoadPngResource(const wchar_t *szName, const wxWindowBase* w);
 
+// Encapsulate a (config) value that can be overridden.
+//   `T` must be copyable and have a (sensible) default constructor.
+template<typename T>
+class OverridableOption
+{
+public:
+	OverridableOption()
+		: is_overridden(false)
+	{}
+	
+	OverridableOption( const T& config_value )
+		: config_value(config_value), is_overridden(false)
+	{}
+
+	// setters
+	void SetConfigValue( const T& new_value )
+	{
+		is_overridden = false;
+		config_value = new_value;
+	}
+	
+	void Override( const T& ovr_value )
+	{
+		is_overridden = true;
+		override_value = ovr_value;
+	}
+
+	// Using this replaces an override value.
+	T& operator =( const T& new_value )
+	{
+		is_overridden = false;
+		config_value = new_value;
+		return config_value;
+	}
+
+	// getters
+	operator T() const
+	{
+		return GetValue();
+	}
+
+	T GetValue() const
+	{
+		return is_overridden ? override_value : config_value;
+	}
+
+	T GetConfigValue() const
+	{
+		return config_value;
+	}
+	T GetOverrideValue() const
+	{
+		return override_value;
+	}
+
+	bool IsOverridden() const
+	{
+		return is_overridden;
+	}
+
+protected:
+	T config_value;
+	bool is_overridden;
+	T override_value;
+};
+
 class Prefs
 {
 public:
 	Prefs()
+		: useSymServer(false), saveMinidump(-1), throttle(100)
 	{
-		useSymServer = false;
-		saveMinidump = -1;
-		throttle = 100;
 		useWinePref = useWineSwitch = useMingwSwitch = false;
 		attachMode = ATTACH_ALL_THREAD;
-
-		// The default behavior is to save them.
-		saveMinidump_nosave = 
-			throttle_nosave = 
-			symSearchPath_nosave = 
-			useSymServer_nosave =
-			symCacheDir_nosave =
-			symServer_nosave = false;
 	}
 
-	wxString symSearchPath;
-	bool useSymServer;
-	wxString symCacheDir;
-	wxString symServer;
-	int saveMinidump; // Save minidump after X seconds. -1 = disabled
-	int throttle;
-
-	// Because the above settings are saved to persistent storage, provide a
-	// 	 means to specify them for a particular run (e.g. command line) without
-	// 	 saving them.
-	bool symSearchPath_nosave;
-	bool useSymServer_nosave;
-	bool symCacheDir_nosave;
-	bool symServer_nosave;
-	bool saveMinidump_nosave;
-	bool throttle_nosave; 
+	OverridableOption<wxString> symSearchPath;
+	OverridableOption<bool> useSymServer;
+	OverridableOption<wxString> symCacheDir;
+	OverridableOption<wxString> symServer;
+	OverridableOption<int> saveMinidump; // Save minidump after X seconds. -1 = disabled
+	OverridableOption<int> throttle;
 
 	bool useWinePref, useWineSwitch, useMingwSwitch;
 	AttachMode attachMode;
@@ -117,11 +163,11 @@ public:
 	// Add any configured search paths, and the symbol server if enabled.
 	void AdjustSymbolPath(std::wstring &sympath, bool download)
 	{
-		if (!symSearchPath.empty())
+		if (!symSearchPath.GetValue().empty())
 		{
 			if (!sympath.empty())
 				sympath += L";";
-			sympath += symSearchPath;
+			sympath += symSearchPath.GetValue();
 		}
 
 		if (useSymServer)
@@ -129,17 +175,19 @@ public:
 			if (!sympath.empty())
 				sympath += L";";
 			sympath += L"SRV*";
-			sympath += symCacheDir;
+			sympath += symCacheDir.GetValue();
 			if ( download )
-				sympath += std::wstring(L"*") + symServer;
+				sympath += std::wstring(L"*") + symServer.GetValue();
 		}
 	}
 
-	void ValidateThrottle() {
-		if (throttle < 1)
-			throttle = 1;
-		if (throttle > 100)
-			throttle = 100;
+	static int ValidateThrottle( int value )
+	{
+		if (value < 1)
+			return 1;
+		if (value > 100)
+			return 100;
+		return value;
 	}
 };
 


### PR DESCRIPTION
    /minidump:<seconds_until_minidump>
    /samplerate:<sample_rate>
    /symsearchpath:<symbol_search_path>
    /symcachedir:<symbol_cache_dir>
    /usesymserver:<use_symbol_server_p>
    /symserver:<symbol_server_URL>

Specifying any of these will alter the behavior of the created sleepy.exe process, but will **not** result in the options (saved in the registry) being changed.
