### PR TITLE
fix memleak, improved compatibility with VS 2022

### DIFF
--- a/sleepy.vcxproj
+++ b/sleepy.vcxproj
@@ -256,6 +256,7 @@
     <ClCompile Include="src\utils\mythread.cpp" />
     <ClCompile Include="src\utils\osutils.cpp" />
     <ClCompile Include="src\utils\sortlist.cpp" />
+	<ClCompile Include="src\utils\stringconversion.cpp" />
     <ClCompile Include="src\utils\stringutils.cpp" />
     <ClCompile Include="src\utils\WoW64.cpp" />
     <ClCompile Include="src\wxProfilerGUI\aboutdlg.cpp" />
@@ -280,6 +281,7 @@
     <ClInclude Include="src\appinfo.h" />
     <ClInclude Include="src\profiler\debugger.h" />
     <ClInclude Include="src\utils\container.h" />
+	<ClInclude Include="src\utils\stringconversion.h" />
     <ClInclude Include="src\wxProfilerGUI\aboutdlg.h" />
     <ClInclude Include="src\wxProfilerGUI\latesymbolinfo.h" />
     <ClInclude Include="src\profiler\processinfo.h" />

--- a/src/profiler/profiler.cpp
+++ b/src/profiler/profiler.cpp
@@ -88,6 +88,8 @@ Profiler::~Profiler()
 
 }
 
+#if !defined(_WIN64)
+
 // There are a couple of things than can cause StackWalk64 to not produce a correct callstack,
 // if we happen to have stopped the process in an unfortunate place.
 //
@@ -149,6 +151,7 @@ void applyHacks(HANDLE process_handle, CONTEXT32 &context)
 		}
 	}
 }
+#endif
 
 bool Profiler::sampleTarget(SAMPLE_TYPE timeSpent, SymbolInfo *syminfo)
 {

--- a/src/utils/except.h
+++ b/src/utils/except.h
@@ -25,6 +25,7 @@ http://www.gnu.org/copyleft/gpl.html..
 
 #include <stdexcept>
 #include <string>
+#include "stringconversion.h"
 
 class SleepyException : public std::runtime_error
 {
@@ -37,8 +38,7 @@ class SleepyException : public std::runtime_error
 		// it will always be initialized after the superclass.
 		// Can't use _what here because it is still not initialized
 		// and contains junk.
-		std::wstring ws(what);
-		return std::string(ws.begin(), ws.end());
+		return toANSI(what);		
 	}
 
 public:
@@ -46,7 +46,7 @@ public:
 		: std::runtime_error(what), _what(std::wstring(what.begin(), what.end())) {}
 
 	SleepyException(const std::wstring &what)
-		: std::runtime_error(std::string(what.begin(), what.end())), _what(what) {}
+		: std::runtime_error(toANSI(what.c_str())), _what(what) {}
 
 	SleepyException(const wchar_t *what)
 		: std::runtime_error(helper(what)), _what(what) {}

--- a/src/utils/stringconversion.cpp
+++ b/src/utils/stringconversion.cpp
@@ -1,0 +1,14 @@
+#include "stringconversion.h"
+#define WIN32_LEAN_AND_MEAN
+#define VC_EXTRALEAN
+#include <Windows.h>
+#include <vector>
+
+std::string toANSI(const wchar_t* what) {
+	const int srcLength = (int)wcslen(what);
+	const int destLength = ::WideCharToMultiByte(CP_ACP, 0, what, srcLength, nullptr, 0, nullptr, nullptr);
+	std::vector<char> destBuffer;
+	destBuffer.resize(destLength);
+	::WideCharToMultiByte(CP_ACP, 0, what, srcLength, destBuffer.data(), destLength, nullptr, nullptr);
+	return std::string(destBuffer.begin(), destBuffer.end());
+}

--- a/src/utils/stringconversion.h
+++ b/src/utils/stringconversion.h
@@ -1,0 +1,3 @@
+#pragma once
+#include <string>
+std::string toANSI(const wchar_t* what);

--- a/src/wxProfilerGUI/database.cpp
+++ b/src/wxProfilerGUI/database.cpp
@@ -134,6 +134,7 @@ void Database::loadFromPath(const std::wstring& _profilepath, bool collapseOSCal
 				wxString ver = name.Mid(8, name.Length()-(8+9));
 				enforce(ver == FORMAT_VERSION, wxString::Format("Cannot load capture file: %s", name.c_str()).c_str());
 			}
+			delete entry;
 		}
 
 		enforce(versionFound, "Unrecognized capture file");
@@ -186,6 +187,10 @@ void Database::loadFromPath(const std::wstring& _profilepath, bool collapseOSCal
 		else if (name.Left(8) == "Version ") continue;
 
 		wxLogWarning("Other fluff found in capture file (%s)\n", name.c_str());
+	}
+	
+	for (auto item : entries) {
+		delete item.second;
 	}
 
 	setRoot(NULL);


### PR DESCRIPTION
profiler.cpp applyHacks definition disabled for x64
database.cpp wxZipEntry memory deleted
except.h conversion from wide strings to ansi strings done via WideCharToMultiByte(CP_ACP)